### PR TITLE
Added support for monolithic .ovpn configuration files

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -174,6 +174,22 @@ define openvpn::client(
             require     => [  File["/etc/openvpn/${server}/download-configs/${name}/${name}.conf"],
                               File["/etc/openvpn/${server}/download-configs/${name}/keys/ca.crt"],
                               File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.key"],
-                              File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.crt"] ];
+                              File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.crt"] ],
+            notify => Exec["generate ${name}.ovpn in ${server}"];
+
     }
+
+    exec {
+      "generate ${name}.ovpn in ${server}":
+        cwd         => "/etc/openvpn/${server}/download-configs/",
+        command     => "/bin/rm ${name}.ovpn; cat  ${name}/${name}.conf|perl -lne 'if(m|^ca keys/ca.crt|){ chomp(\$ca=`cat ${name}/keys/ca.crt`); print \"<ca>\n\$ca\n</ca>\"} elsif(m|^cert keys/${name}.crt|) { chomp(\$crt=`cat ${name}/keys/${name}.crt`); print \"<cert>\n\$crt\n</cert>\"} elsif(m|^key keys/${name}.key|){ chomp(\$key=`cat ${name}/keys/${name}.key`); print \"<key>\n\$key\n</key>\"} else { print} ' > ${name}.ovpn",
+        refreshonly => true,
+        require     => [  File["/etc/openvpn/${server}/download-configs/${name}/${name}.conf"],
+                          File["/etc/openvpn/${server}/download-configs/${name}/keys/ca.crt"],
+                          File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.key"],
+                          File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.crt"],
+        ],
+    }
+
+
 }


### PR DESCRIPTION
Useful for distributing configurations to mobile devices.

The solution is not the best, instead of a template I used an exec to do some substitution. This because there is the need of being root and templates are evaluated/compiled on the master, running as 'puppet' user.
