### PR TITLE
Fix Modulefile dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description 'Puppet module to manage OpenVPN servers'
 project_page 'https://github.com/luxflux/puppet-openvpn'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat'
+dependency 'ripienaar/concat', '0.2.0'


### PR DESCRIPTION
Set the version of the concat module dependency in Modulefile. Otherwise it doesn't work with librarian-puppet.
