### PR TITLE
Fix permissions for ovpn file

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -179,4 +179,9 @@ define openvpn::client(
                         File["/etc/openvpn/${server}/download-configs/${name}/keys/${name}.crt"],
                       ],
   }
+
+  file { "/etc/openvpn/${server}/download-configs/${name}.ovpn":
+    mode    => '0400',
+    require => Exec["generate ${name}.ovpn in ${server}"],
+  }
 }


### PR DESCRIPTION
Generated ovpn files contain secrets and should be readable from root user only
