### PR TITLE
Switch the ripienaar/concat dependency to puppetlabs/concat.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
-name    'luxflux-openvpn'
+name 'luxflux-openvpn'
 version '2.1.0'
 source 'https://github.com/luxflux/puppet-openvpn'
 author 'luxflux'
@@ -8,4 +8,4 @@ description 'Puppet module to manage OpenVPN servers'
 project_page 'https://github.com/luxflux/puppet-openvpn'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '0.2.0'
+dependency 'puppetlabs/concat', '>= 1.0.0'

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -13,7 +13,7 @@ Tested on Ubuntu Precise Pangolin, CentOS 6, RedHat 6.
 
 
 ## Dependencies
-  - [puppet-concat](https://github.com/ripienaar/puppet-concat)
+  - [puppetlabs-concat 1.0.0+](https://github.com/puppetlabs/puppet-concat)
 
 
 ## Example


### PR DESCRIPTION
Update the module and readme files. The ripienaar/concat module is no longer being updated and puppetlabs/concat is it's replacement.
