### PR TITLE
Ubuntu 13.10 has the easy-rsa package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class openvpn::params {
       }
     }
     default: { # Debian/Ubuntu
-      if($::operatingsystemmajrelease == 'jessie/sid'){
+      if($::operatingsystemmajrelease == 'jessie/sid' or $::lsbdistdescription == 'Ubuntu 13.10'){
       package { 'easy-rsa':
             ensure => installed,
           }


### PR DESCRIPTION
Ubuntu 13.10 has the easy-rsa package

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
