### PR TITLE
replace ripienaar/concat with puppetlabs/concat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
-    concat: git://github.com/ripienaar/puppet-concat.git
+    concat: https://github.com/puppetlabs/puppetlabs-concat.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
     openvpn: "#{source_dir}"
 

--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,6 @@ description 'Puppet module to manage OpenVPN servers'
 project_page 'https://github.com/luxflux/puppet-openvpn'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat'
+dependency 'puppetlabs/concat'
+dependency 'puppetlabs/stdlib'
+


### PR DESCRIPTION
Ri.I. no longer maintains his concat module, PL has taken over it.  This also requires the addition of stdlib.
