### PR TITLE
fix stdlib dependency line

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,4 @@ project_page 'https://github.com/luxflux/puppet-openvpn'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/concat', '>= 1.0.0'
-dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/stdlib', '>= 1.0.0'


### PR DESCRIPTION
https://github.com/luxflux/puppet-openvpn/commit/943d022a1c67d252b246e3b63a67e5507fe8386f#diff-399082633b0e95792454ae14398be6ee breaks the use of this module with https://github.com/rodjek/librarian-puppet because of missing version number
