### PR TITLE
Ensure packages expects an array and doesn't work with undef

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,10 @@
 class openvpn::install {
 
   ensure_packages(['openvpn'])
-  ensure_packages($::openvpn::params::additional_packages)
+  if $::openvpn::params::additional_packages != undef {
+    ensure_packages( any2array($::openvpn::params::additional_packages) )
+  }
+
 
   file {
     [ '/etc/openvpn', '/etc/openvpn/keys' ]:


### PR DESCRIPTION
Commit https://github.com/luxflux/puppet-openvpn/commit/d31a0112ebeed702c821ccac878bce15a84bdb8c breaks module on Debian 7 (Wheezy) with last Puppet (from puppetlabs repositories) version (3.4.0)

Parser fails on line 36 of install.pp:

```
Error: ensure_packages(): Requires array given (String) at /opt/puppet/modules/openvpn/manifests/install.pp:36 on node xxx
```

Fixing line 36 gives another error on line 37:

```
Error: ensure_packages(): Requires array given (String) at /opt/puppet/modules/openvpn/manifests/install.pp:37 on node xxx
```

Wrapping $::openvpn::params::additional_package on any2arry doesn't worke alone causing another parser error (which might be particular to my setup):

```
Error: Could not find resource 'Package[]' for relationship from 'Apt::Source[non-free]' on node xxx
```

So playing for safe I've added an if statment checking $::openvpn::params::additional_package

I don't know if some test coverage for this case should be added
