### PR TITLE
Set $remote_host to match the OpenVPN server name

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -111,7 +111,7 @@ define openvpn::client(
   $persist_tun = true,
   $port = '1194',
   $proto = 'tcp',
-  $remote_host = $::fqdn,
+  $remote_host = $server,
   $resolv_retry = 'infinite',
   $verb = '3',
 ) {


### PR DESCRIPTION
Currently the openvpn client configs use the FQDN of the server instead of the server name chosen in the puppet manifest. Client configs should use server as defined in "openvpn::client".
