### PR TITLE
Added option for server-bridge directive

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,6 +70,10 @@
 #   String.  Network to assign client addresses out of
 #   Default: None.  Required in tun mode, not in tap mode
 #
+# [*server_bridge*]
+#   String. Server configuration to comply with existing DHCP server
+#   Default: None.
+#
 # [*push*]
 #   Array.  Options to push out to the client.  This can include routes, DNS
 #     servers, DNS search domains, and many other options.
@@ -173,6 +177,7 @@ define openvpn::server(
   $proto = 'tcp',
   $status_log = "${name}/openvpn-status.log",
   $server = '',
+  $server_bridge = '',
   $push = [],
   $route = [],
   $keepalive = '',

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -33,6 +33,9 @@ ifconfig-pool-persist <%= scope.lookupvar('name') %>/vpn-ipp.txt
 <% if scope.lookupvar('server') != '' -%>
 server <%= scope.lookupvar('server') %>
 <% end -%>
+<% if scope.lookupvar('server_bridge') != '' -%>
+server-bridge <%= scope.lookupvar('server_bridge') %>
+<% end -%>
 <% scope.lookupvar('push').each do |item| -%>
 push "<%= item %>"
 <% end -%>


### PR DESCRIPTION
When creating openvpn in bridged mode, this is very usefull configuration option. Useful resources: http://openvpn.net/index.php/open-source/faq/77-server/323-i-want-to-set-up-an-ethernet-bridge-on-the-1921681024-subnet-existing-dhcp.html
