### PR TITLE
Added options for cipher, verb, persist-key, persist-tun server directives. Added options for KEY_EXPIRE, CA_EXPIRE, KEY_NAME, KEY_OU, KEY_CN easy-rsa vars.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -129,6 +129,44 @@
 #   String,  Script which we want to run when openvpn server starts
 #   Default: None
 #
+# [*verb*]
+#   Integer.  Level of logging verbosity
+#   Default: 3
+#
+# [*cipher*]
+#   String,  Cipher to use for packet encryption
+#   Default: None
+#
+# [*persist_key*]
+#   Boolean.  Try to retain access to resources that may be unavailable
+#     because of privilege downgrades
+#   Default: false
+#
+# [*persist_tun*]
+#   Boolean.  Try to retain access to resources that may be unavailable
+#     because of privilege downgrades
+#   Default: false
+#
+# [*key_expire*]
+#   String.  The number of days to certify the server certificate for
+#   Default: 3650
+#
+# [*ca_expire*]
+#   String.  The number of days to certify the CA certificate for
+#   Default: 3650
+#
+# [*key_name*]
+#   String,  Value for name_default variable in openssl.cnf (and KEY_NAME in vars)
+#   Default: None
+#
+# [*key_ou*]
+#   String,  Value for organizationalUnitName_default variable in openssl.cnf (and KEY_OU in vars)
+#   Default: None
+#
+# [*key_cn*]
+#   String,  Value for commonName_default variable in openssl.cnf (and KEY_CN in vars)
+#   Default: None
+#
 # === Examples
 #
 #   openvpn::client {
@@ -195,6 +233,15 @@ define openvpn::server(
   $management_ip = 'localhost',
   $management_port = 7505,
   $up = '',
+  $ca_expire = 3650,
+  $key_expire = 3650,
+  $key_cn = '',
+  $key_name = '',
+  $key_ou = '',
+  $verb = '',
+  $cipher = '',
+  $persist_key = false,
+  $persist_tun = false,
 ) {
 
   include openvpn

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -48,8 +48,20 @@ keepalive <%= scope.lookupvar('keepalive') %>
 <% if scope.lookupvar('topology') != '' -%>
 topology <%= scope.lookupvar('topology') %>
 <% end -%>
+<% if scope.lookupvar('verb') != '' -%>
+verb <%= scope.lookupvar('verb') %>
+<% end -%>
+<% if scope.lookupvar('cipher') != '' -%>
+cipher <%= scope.lookupvar('cipher') %>
+<% end -%>
 <% if scope.lookupvar('c2c') -%>
 client-to-client
+<% end -%>
+<% if scope.lookupvar('persist_key') -%>
+persist-key
+<% end -%>
+<% if scope.lookupvar('persist_tun') -%>
+persist-tun
 <% end -%>
 <% if scope.lookupvar('tcp_nodelay') -%>
 tcp-nodelay

--- a/templates/vars.erb
+++ b/templates/vars.erb
@@ -53,10 +53,10 @@ export PKCS11_PIN="dummy"
 export KEY_SIZE=<%= @ssl_key_size %>
 
 # In how many days should the root CA key expire?
-export CA_EXPIRE=3650
+export CA_EXPIRE=<%= @ca_expire %>
 
 # In how many days should certificates expire?
-export KEY_EXPIRE=3650
+export KEY_EXPIRE=<%= @key_expire %>
 
 # These are the default values for fields
 # which will be placed in the certificate.
@@ -66,3 +66,12 @@ export KEY_PROVINCE="<%= @province %>"
 export KEY_CITY="<%= @city %>"
 export KEY_ORG="<%= @organization %>"
 export KEY_EMAIL="<%= @email %>"
+<% if @key_cn != '' -%>
+export KEY_CN="<%= @key_cn %>"
+<% end -%>
+<% if @key_name != '' -%>
+export KEY_NAME="<%= @key_name %>"
+<% end -%>
+<% if @key_ou != '' -%>
+export KEY_OU="<%= @key_ou %>"
+<% end -%>


### PR DESCRIPTION
Hi,

I added support for nine variables, 4 of them to further tune the server openvpn configuration, 5 of them to further tune the easy-rsa vars.

I'm pushing the 9 vars as one change in the extensions branch. I also have separate feature branches for each of the variables if you wish.

Last but not least, each variable is accompanied with a documenting line as well.

Best Regards,
Ewout
