### PR TITLE
Manage files in /etc/openvpn/

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,9 +32,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class openvpn {
+class openvpn (
+  $cleanup = $::openvpn::params::cleanup,
+) inherits openvpn::params {
 
-  class {'openvpn::params': } ->
   class {'openvpn::install': } ->
   class {'openvpn::config': } ~>
   class {'openvpn::service': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,8 +41,8 @@ class openvpn::install {
   file { '/etc/openvpn':
     ensure  => directory,
     require => Package['openvpn'],
-    recurse => true,
-    purge   => true,
+    recurse => $::openvpn::cleanup,
+    purge   => $::openvpn::cleanup,
   }
 
   file { '/etc/openvpn/keys':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,4 +50,6 @@ class openvpn::params {
     default           => false
   }
 
+  $cleanup = false
+
 }


### PR DESCRIPTION
This is opt-in to avoid deleting none managed configuration files.
