### PR TITLE
Change the CN of the server certificate

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,6 +20,10 @@
 # [*email*]
 #   String.  Email address to be used for the SSL certificate
 #
+# [*common_name*]
+#   String.  Common name to be used for the SSL certificate
+#   Default: server
+#
 # [*compression*]
 #   String.  Which compression algorithim to use
 #   Default: comp-lzo
@@ -232,6 +236,7 @@ define openvpn::server(
   $city,
   $organization,
   $email,
+  $common_name = 'server',
   $compression = 'comp-lzo',
   $dev = 'tun0',
   $user = 'nobody',
@@ -354,9 +359,9 @@ define openvpn::server(
                     File["/etc/openvpn/${name}/easy-rsa/openssl.cnf"] ];
 
     "generate server cert ${name}":
-      command  => '. ./vars && ./pkitool --server server',
+      command  => ". ./vars && ./pkitool --server ${common_name}",
       cwd      => "/etc/openvpn/${name}/easy-rsa",
-      creates  => "/etc/openvpn/${name}/easy-rsa/keys/server.key",
+      creates  => "/etc/openvpn/${name}/easy-rsa/keys/${common_name}.key",
       provider => 'shell',
       require  => Exec["initca ${name}"];
   }

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -1,8 +1,8 @@
 mode server
 client-config-dir /etc/openvpn/<%= scope.lookupvar('name') %>/client-configs
 ca /etc/openvpn/<%= scope.lookupvar('name') %>/keys/ca.crt
-cert /etc/openvpn/<%= scope.lookupvar('name') %>/keys/server.crt
-key /etc/openvpn/<%= scope.lookupvar('name') %>/keys/server.key
+cert /etc/openvpn/<%= scope.lookupvar('name') %>/keys/<%= scope.lookupvar('common_name') %>.crt
+key /etc/openvpn/<%= scope.lookupvar('name') %>/keys/<%= scope.lookupvar('common_name') %>.key
 dh /etc/openvpn/<%= scope.lookupvar('name') %>/keys/dh<%= scope.lookupvar('ssl_key_size') %>.pem
 crl-verify /etc/openvpn/<%= scope.lookupvar('name') %>/crl.pem
 <% if scope.lookupvar('proto') == 'tcp' -%>


### PR DESCRIPTION
Small change that I added to allow changing the common name of the server certificate, defaults to 'server' as before.
