### PR TITLE
Config error on Ubuntu 14.04 

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -380,7 +380,7 @@ define openvpn::server(
 
   exec {
     "create crl.pem on ${name}":
-      command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' openssl ca -gencrl -out /etc/openvpn/${name}/crl.pem -config /etc/openvpn/${name}/easy-rsa/openssl.cnf",
+      command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out /etc/openvpn/${name}/crl.pem -config /etc/openvpn/${name}/easy-rsa/openssl.cnf",
       cwd      => "/etc/openvpn/${name}/easy-rsa",
       creates  => "/etc/openvpn/${name}/crl.pem",
       provider => 'shell',


### PR DESCRIPTION
Hey, thanks for the prompt resolution on the previous bug, I was about to have a look at it myself but you beat me to it.

I've come across another issue (note - replaced my domain name):

```
Notice: /Stage[main]/Main/Node[vpn.blah.net]/Openvpn::Server[vpn.blah.net]/Exec[create crl.pem on vpn.blah.net]/returns: Using configuration from /etc/openvpn/vpn.blah.net/easy-rsa/openssl.cnf
Notice: /Stage[main]/Main/Node[vpn.blah.net]/Openvpn::Server[vpn.blah.net]/Exec[create crl.pem on vpn.blah.net]/returns: error on line 198 of config file '/etc/openvpn/vpn.blah.net/easy-rsa/openssl.cnf'
Notice: /Stage[main]/Main/Node[vpn.blah.net]/Openvpn::Server[vpn.blah.net]/Exec[create crl.pem on vpn.blah.net]/returns: 140001620666016:error:0E065068:configuration file routines:STR_COPY:variable has no value:conf_def.c:618:line 198
Error: . ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' openssl ca -gencrl -out /etc/openvpn/vpn.blah.net/crl.pem -config /etc/openvpn/vpn.blah.net/easy-rsa/openssl.cnf returned 1 instead of one of [0]
Error: /Stage[main]/Main/Node[vpn.blah.net]/Openvpn::Server[vpn.blah.net]/Exec[create crl.pem on vpn.blah.net]/returns: change from notrun to 0 failed: . ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' openssl ca -gencrl -out /etc/openvpn/vpn.blah.net/crl.pem -config /etc/openvpn/vpn.blah.net/easy-rsa/openssl.cnf returned 1 instead of one of [0]
```

Line 198 was this:

```
subjectAltName=$ENV::KEY_ALTNAMES
```

I commented it out and got another one:

```
Notice: /Stage[main]/Main/Node[vpn.blah.net]/Openvpn::Server[vpn.blah.net]/Exec[create crl.pem on vpn.blah.net]/returns: error on line 220 of config file '/etc/openvpn/vpn.blah.net/easy-rsa/openssl.cnf'
```

Line 220 is the same:

```
subjectAltName=$ENV::KEY_ALTNAMES
```

Commented out again and worked. Let me know if I can provide anything else to assist.
