### PR TITLE
Only warn about pam if it's used

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -124,7 +124,9 @@ define openvpn::client(
   $authuserpass = false,
 ) {
 
-  warning('Using $pam is deprecated. Use $authuserpass instead!')
+  if $pam {
+    warning('Using $pam is deprecated. Use $authuserpass instead!')
+  }
 
   Openvpn::Server[$server] ->
   Openvpn::Client[$name]


### PR DESCRIPTION
On upgrading to the most recent master here, I got complaints like this:

```
Warning: Scope(Openvpn::Client[user1@vpn.clanspum.net]): Using $pam is deprecated. Use $authuserpass instead!
Warning: Scope(Openvpn::Client[user2@vpn.clanspum.net]): Using $pam is deprecated. Use $authuserpass instead!
Warning: Scope(Openvpn::Client[user3@vpn.clanspum.net]): Using $pam is deprecated. Use $authuserpass instead!
Warning: Scope(Openvpn::Client[user4@vpn.clanspum.net]): Using $pam is deprecated. Use $authuserpass instead!
```

I never used `$pam`, so I was surprised.  I added a little logic around it to only warn if `$pam` is set to something.
