### PR TITLE
Add 'push' option to access push for generic settings

### DIFF
--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -30,8 +30,8 @@
 #   Default: false
 #
 # [*push]
-#   Array.  Redirect all traffic to gateway
-#   Default: false
+#   Array.  Add other options like routes (non-iroute) to be pushed.
+#   Default: []
 #
 # === Examples
 #

--- a/templates/client_specific_config.erb
+++ b/templates/client_specific_config.erb
@@ -10,5 +10,6 @@ push dhcp-option <%= option %>
 <% if @redirect_gateway -%>
 push redirect-gateway def1
 <% end %>
-<% if scope.lookupvar('push').each do |option| -%>
+<% scope.lookupvar('push').each do |push_option| -%>
+	push <%= push_option %>
 <% end %>


### PR DESCRIPTION
Hey there,

at a customer we have to add some pushes for specific configuration to the OpenVPN, but the module thus far had no support for that. I just cleaned up our old hack, you might want to consider it.

Cheers,
-towo
