### PR TITLE
Changes for PAM support needed on RHEL7/Centos7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Next Version
 
+* Fix broken namespecific rclink ([#209](https://github.com/luxflux/puppet-openvpn/pull/209))
+
 ## 4.0.1
 
-* Fix namespecific_rclink warning for non BSD systems ([#214](https://github.com/luxflux/puppet-openvpn/pull/214))
+* Fix namespecific_rclink variable warning for non BSD systems ([#214](https://github.com/luxflux/puppet-openvpn/pull/214))
 
 ## 4.0.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,27 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :unit_tests do
   gem 'rake',                    :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint', '1.0.1',    :require => false
+  gem 'puppet-lint',             :require => false
   gem 'puppet-syntax',           :require => false
   gem 'metadata-json-lint',      :require => false
 end
 
 group :development do
   gem 'simplecov',   :require => false
-  gem 'guard-rake',  :require => false
+#  gem 'guard-rake',  :require => false
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
-  if puppetversion == "~> 2.7.0"
-    gem 'hiera-puppet', :require => false
-    gem 'hiera', :require => false
-  end
 else
   gem 'puppet', :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :unit_tests do
   gem 'puppet-lint',             :require => false
   gem 'puppet-syntax',           :require => false
   gem 'metadata-json-lint',      :require => false
+  gem 'rspec-puppet-facts',      :require => false
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,6 @@ exclude_paths = [
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.fail_on_warnings
 PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/Rakefile
+++ b/Rakefile
@@ -8,13 +8,13 @@ exclude_paths = [
   "spec/**/*",
 ]
 
-PuppetLint.configuration.relative = true
-PuppetLint.configuration.fail_on_warnings
-PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetLint.configuration.send('relative')
-PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-PuppetSyntax.exclude_paths = exclude_paths
+Rake::Task[:lint].clear
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = exclude_paths
+  config.disable_checks = ['140chars']
+  config.fail_on_warnings = true
+  config.disable_class_inherits_from_params_class = true
+end
 
 desc "Run acceptance tests"
 RSpec::Core::RakeTask.new(:acceptance) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -21,14 +21,10 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-task :metadata do
-  sh "metadata-json-lint metadata.json"
-end
-
 desc "Run syntax, lint, and spec tests."
 task :test => [
   :syntax,
   :lint,
-  :metadata,
+  :metadata_lint,
   :spec,
 ]

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ PuppetLint::RakeTask.new :lint do |config|
   config.ignore_paths = exclude_paths
   config.disable_checks = ['140chars']
   config.fail_on_warnings = true
-  config.disable_class_inherits_from_params_class = true
 end
 
 desc "Run acceptance tests"

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -100,13 +100,13 @@ define openvpn::ca(
   $ssl_key_size = 1024,
   $ca_expire    = 3650,
   $key_expire   = 3650,
-  $key_cn       = '',
-  $key_name     = '',
-  $key_ou       = '',
+  $key_cn       = undef,
+  $key_name     = undef,
+  $key_ou       = undef,
   $tls_auth     = false,
 ) {
 
-  include openvpn
+  include ::openvpn
 
   $group_to_set = $group ? {
     false   => $openvpn::params::group,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -205,8 +205,8 @@ define openvpn::client(
   $authuserpass         = false,
   $setenv               = {},
   $setenv_safe          = {},
-  $up                   = '',
-  $down                 = '',
+  $up                   = undef,
+  $down                 = undef,
   $tls_auth             = false,
   $x509_name            = undef,
   $sndbuf               = undef,
@@ -242,7 +242,7 @@ define openvpn::client(
       warning("Custom expiry time ignored: only integer is accepted but ${expire} is given.")
     }
   } else {
-    $env_expire = ''
+    $env_expire = undef
   }
 
   exec { "generate certificate for ${name} in context of ${ca_name}":
@@ -349,80 +349,80 @@ define openvpn::client(
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/client_config":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => template('openvpn/client.erb'),
-    order   => '01'
+    order   => '01',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/ca_open_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "# Authentication \n<ca>\n",
-    order   => '02'
+    order   => '02',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/ca":
     target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     source => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/ca.crt",
-    order  => '03'
+    order  => '03',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/ca_close_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "</ca>\n",
-    order   => '04'
+    order   => '04',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/key_open_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "<key>\n",
-    order   => '05'
+    order   => '05',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/key":
     target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     source => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/${name}.key",
-    order  => '06'
+    order  => '06',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/key_close_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "</key>\n",
-    order   => '07'
+    order   => '07',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/cert_open_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "<cert>\n",
-    order   => '08'
+    order   => '08',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/cert":
     target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     source => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/${name}.crt",
-    order  => '09'
+    order  => '09',
   }
 
   concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/cert_close_tag":
     target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
     content => "</cert>\n",
-    order   => '10'
+    order   => '10',
   }
 
   if $tls_auth {
     concat::fragment { "/etc/openvpn/${server}/download-configs/${name}.ovpn/tls_auth_open_tag":
       target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
       content => "<tls-auth>\n",
-      order   => '11'
+      order   => '11',
     }
 
     concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/tls_auth":
       target => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
       source => "${etc_directory}/openvpn/${server}/download-configs/${name}/keys/${name}/ta.key",
-      order  => '12'
+      order  => '12',
     }
 
     concat::fragment { "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn/tls_auth_close_tag":
       target  => "${etc_directory}/openvpn/${server}/download-configs/${name}.ovpn",
       content => "</tls-auth>\nkey-direction 1\n",
-      order   => '13'
+      order   => '13',
     }
   }
 }

--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -93,7 +93,7 @@ define openvpn::client_specific_config(
 
   file { "${::openvpn::params::etc_directory}/openvpn/${server}/client-configs/${name}":
     ensure  => $ensure,
-    content => template('openvpn/client_specific_config.erb')
+    content => template('openvpn/client_specific_config.erb'),
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   Hash of defaults for clients passed to openvpn::client defined type.
 #   Default: {} (hiera_hash)
 # [*clients*]
-#   Hash of clients passed to openvpn::client defined type. 
+#   Hash of clients passed to openvpn::client defined type.
 #   Default: {} (hiera_hash)
 # [*client_specific_config_defaults*]
 #   Hash of defaults for client specific configurations passed to
@@ -90,13 +90,13 @@ class openvpn (
   validate_hash($server_defaults)
   validate_hash($servers)
 
-  class { 'openvpn::params': } ->
-  class { 'openvpn::install': } ->
-  class { 'openvpn::config': } ->
-  Class['openvpn']
+  class { '::openvpn::params': } ->
+  class { '::openvpn::install': } ->
+  class { '::openvpn::config': } ->
+  Class['::openvpn']
 
   if ! $::openvpn::params::systemd {
-    class { 'openvpn::service':
+    class { '::openvpn::service':
       subscribe => [Class['openvpn::config'], Class['openvpn::install'] ],
     }
     if empty($servers) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class openvpn::params {
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
         $systemd = true
-        $pam_module_path     = '/usr/lib64/openvpn/plugins/lib/openvpn-auth-pam.so'
+        $pam_module_path     = '/usr/lib64/openvpn/plugins/openvpn-auth-pam.so'
       # Redhat/Centos < 7
       } else {
         $systemd = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class openvpn::params {
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
         $systemd = true
-        $pam_module_path     = '/usr/lib64/openvpn/plugins/openvpn-auth-pam.so'
+        $pam_module_path     = '/usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so'
       # Redhat/Centos < 7
       } else {
         $systemd = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class openvpn::params {
       $root_group          = 'root'
       $group               = 'nobody'
       $link_openssl_cnf    = true
-      $pam_module_path     = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
       $additional_packages = ['easy-rsa']
       $easyrsa_source      = '/usr/share/easy-rsa/2.0'
       $namespecific_rclink = false
@@ -30,9 +29,11 @@ class openvpn::params {
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
         $systemd = true
+        $pam_module_path     = '/usr/lib64/openvpn/plugins/lib/openvpn-auth-pam.so'
       # Redhat/Centos < 7
       } else {
         $systemd = false
+        $pam_module_path     = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so'
       }
 
       $ldap_auth_plugin_location = undef # no ldap plugin on redhat/centos

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -439,15 +439,15 @@ define openvpn::server(
   $port                      = '1194',
   $portshare                 = undef,
   $proto                     = 'tcp',
-  $status_version            = '',
+  $status_version            = undef,
   $status_log                = "/var/log/openvpn/${name}-status.log",
-  $server                    = '',
-  $server_ipv6               = '',
-  $server_bridge             = '',
+  $server                    = undef,
+  $server_ipv6               = undef,
+  $server_bridge             = undef,
   $push                      = [],
   $route                     = [],
   $route_ipv6                = [],
-  $keepalive                 = '',
+  $keepalive                 = undef,
   $fragment                  = false,
   $ssl_key_size              = 1024,
   $topology                  = 'net30',
@@ -459,32 +459,32 @@ define openvpn::server(
   $management                = false,
   $management_ip             = 'localhost',
   $management_port           = 7505,
-  $up                        = '',
-  $down                      = '',
+  $up                        = undef,
+  $down                      = undef,
   $username_as_common_name   = false,
   $client_cert_not_required  = false,
   $ldap_enabled              = false,
-  $ldap_server               = '',
-  $ldap_binddn               = '',
-  $ldap_bindpass             = '',
-  $ldap_u_basedn             = '',
-  $ldap_g_basedn             = '',
+  $ldap_server               = undef,
+  $ldap_binddn               = undef,
+  $ldap_bindpass             = undef,
+  $ldap_u_basedn             = undef,
+  $ldap_g_basedn             = undef,
   $ldap_gmember              = false,
-  $ldap_u_filter             = '',
-  $ldap_g_filter             = '',
-  $ldap_memberatr            = '',
+  $ldap_u_filter             = undef,
+  $ldap_g_filter             = undef,
+  $ldap_memberatr            = undef,
   $ldap_tls_enable           = false,
-  $ldap_tls_ca_cert_file     = '',
-  $ldap_tls_ca_cert_dir      = '',
-  $ldap_tls_client_cert_file = '',
-  $ldap_tls_client_key_file  = '',
+  $ldap_tls_ca_cert_file     = undef,
+  $ldap_tls_ca_cert_dir      = undef,
+  $ldap_tls_client_cert_file = undef,
+  $ldap_tls_client_key_file  = undef,
   $ca_expire                 = 3650,
   $key_expire                = 3650,
-  $key_cn                    = '',
-  $key_name                  = '',
-  $key_ou                    = '',
-  $verb                      = '',
-  $cipher                    = '',
+  $key_cn                    = undef,
+  $key_name                  = undef,
+  $key_ou                    = undef,
+  $verb                      = undef,
+  $cipher                    = undef,
   $tls_cipher                = undef,
   $persist_key               = false,
   $persist_tun               = false,
@@ -511,8 +511,8 @@ define openvpn::server(
   $custom_options            = {},
 ) {
 
-  include openvpn
-  Class['openvpn::install'] ->
+  include ::openvpn
+  Class['::openvpn::install'] ->
   Openvpn::Server[$name]
 
   if $::openvpn::params::systemd and $::openvpn::params::namespecific_rclink {
@@ -679,9 +679,11 @@ define openvpn::server(
   }
 
   if $ldap_enabled == true {
+    validate_string($ldap_server)
+
     file {
       "${etc_directory}/openvpn/${name}/auth/ldap.conf":
-        ensure  => present,
+        ensure  => file,
         owner   => root,
         mode    => '0400',
         content => template('openvpn/ldap.erb'),

--- a/spec/classes/openvpn_config_spec.rb
+++ b/spec/classes/openvpn_config_spec.rb
@@ -1,31 +1,40 @@
 require 'spec_helper'
 
-describe 'openvpn::config', :type => :class do
-  it { should create_class('openvpn::config') }
+describe 'openvpn::config' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
 
-  context "on Debian based machines" do
-    let (:facts) { {
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '7',
-      concat_basedir: '/var/lib/puppet/concat'
-    } }
+      it { is_expected.to compile.with_all_deps }
 
-    it { should contain_concat('/etc/default/openvpn') }
-    it { should contain_concat__fragment('openvpn.default.header') }
+      it { should create_class('openvpn::config') }
 
-    context "enabled autostart_all" do
-      let(:pre_condition) { 'class { "openvpn": autostart_all => true }' }
-      it { should contain_concat__fragment('openvpn.default.header').with(
-        'content' => /^AUTOSTART="all"/
-      )}
-    end
+      if facts[:osfamily] == 'Debian'
+        it { should contain_concat('/etc/default/openvpn') }
+        it { should contain_concat__fragment('openvpn.default.header') }
+      end
+#  context "on Debian based machines" do
+#    let (:facts) { {
+#      osfamily: 'Debian',
+#      operatingsystem: 'Debian',
+#      operatingsystemrelease: '7',
+#      concat_basedir: '/var/lib/puppet/concat'
+#    } }
 
-    context "disabled autostart_all" do
-      let(:pre_condition) { 'class { "openvpn": autostart_all => false }' }
-      it { should contain_concat__fragment('openvpn.default.header').with(
-        'content' => /^AUTOSTART=""/
-      )}
+
+      context "enabled autostart_all" do
+        let(:pre_condition) { 'class { "openvpn": autostart_all => true }' }
+        it { should contain_concat__fragment('openvpn.default.header').with(
+          'content' => /^AUTOSTART="all"/
+        )}
+      end
+
+      context "disabled autostart_all" do
+        let(:pre_condition) { 'class { "openvpn": autostart_all => false }' }
+        it { should contain_concat__fragment('openvpn.default.header').with(
+          'content' => /^AUTOSTART=""/
+        )}
+      end
     end
   end
 end

--- a/spec/classes/openvpn_config_spec.rb
+++ b/spec/classes/openvpn_config_spec.rb
@@ -1,26 +1,15 @@
 require 'spec_helper'
 
-describe 'openvpn::config' do
-  on_supported_os.each do |os, facts|
-    context "on #{os}" do
-      let(:facts) { facts }
+describe 'openvpn::config', :type => :class do
 
-      it { is_expected.to compile.with_all_deps }
+  it { should create_class('openvpn::config') }
 
-      it { should create_class('openvpn::config') }
-
-      if facts[:osfamily] == 'Debian'
-        it { should contain_concat('/etc/default/openvpn') }
-        it { should contain_concat__fragment('openvpn.default.header') }
-      end
-#  context "on Debian based machines" do
-#    let (:facts) { {
-#      osfamily: 'Debian',
-#      operatingsystem: 'Debian',
-#      operatingsystemrelease: '7',
-#      concat_basedir: '/var/lib/puppet/concat'
-#    } }
-
+  context "on Debian based machines" do
+    let (:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :concat_basedir => '/var/lib/puppet/concat'
+    } }
 
       context "enabled autostart_all" do
         let(:pre_condition) { 'class { "openvpn": autostart_all => true }' }
@@ -34,7 +23,6 @@ describe 'openvpn::config' do
         it { should contain_concat__fragment('openvpn.default.header').with(
           'content' => /^AUTOSTART=""/
         )}
-      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,51 @@
+#require 'bundler/setup'
+#require 'puppetlabs_spec_helper/module_spec_helper'
+#
+#RSpec.configure do |c|
+#  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+#end
 require 'bundler/setup'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
+
 
 RSpec.configure do |c|
+  c.include PuppetlabsSpec::Files
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+
+
+  c.before :each do
+    # Store any environment variables away to be restored later
+    @old_env = {}
+    ENV.each_key {|k| @old_env[k] = ENV[k]}
+
+    c.strict_variables = Gem::Version.new(Puppet.version) >= Gem::Version.new('3.5')
+    Puppet.features.stubs(:root?).returns(true)
+  end
+
+  c.after :each do
+    PuppetlabsSpec::Files.cleanup
+  end
+end
+
+require 'pathname'
+dir = Pathname.new(__FILE__).parent
+Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
+
+# There's no real need to make this version dependent, but it helps find
+# regressions in Puppet
+#
+# 1. Workaround for issue #16277 where default settings aren't initialised from
+# a spec and so the libdir is never initialised (3.0.x)
+# 2. Workaround for 2.7.20 that now only loads types for the current node
+# environment (#13858) so Puppet[:modulepath] seems to get ignored
+# 3. Workaround for 3.5 where context hasn't been configured yet,
+# ticket https://tickets.puppetlabs.com/browse/MODULES-823
+#
+ver = Gem::Version.new(Puppet.version.split('-').first)
+if Gem::Requirement.new("~> 2.7.20") =~ ver || Gem::Requirement.new("~> 3.0.0") =~ ver || Gem::Requirement.new("~> 3.5") =~ ver || Gem::Requirement.new("~> 4.0")
+  puts "augeasproviders: setting Puppet[:libdir] to work around broken type autoloading"
+  # libdir is only a single dir, so it can only workaround loading of one external module
+  Puppet[:libdir] = "#{Puppet[:modulepath]}/augeasproviders_core/lib"
 end

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -49,13 +49,13 @@ setenv <%= key %> <%= value %>
 <% @setenv_safe.each do |key, value| -%>
 setenv_safe <%= key %> <%= value %>
 <% end -%>
-<% if @up != '' or @down != ''-%>
+<% if @up or @down -%>
 script-security 2
 <% end -%>
-<% if @up != '' -%>
+<% if @up -%>
 up "<%= @up %>"
 <% end -%>
-<% if @down != '' -%>
+<% if @down -%>
 down "<%= @down %>"
 <% end -%>
 <% if @x509_name -%>

--- a/templates/ldap.erb
+++ b/templates/ldap.erb
@@ -1,6 +1,6 @@
 <LDAP>
   URL <%= @ldap_server %>
-<% if @ldap_binddn != '' and @ldap_bindpass != '' -%>
+<% if @ldap_binddn and @ldap_bindpass -%>
   BindDN <%= @ldap_binddn %>
   Password <%= @ldap_bindpass %>
 <% end -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -53,7 +53,7 @@ tls-server
 <% if @tls_client -%>
 tls-client
 <% end -%>
-<% if @compression != '' -%>
+<% if @compression -%>
 <%= @compression %>
 <% end -%>
 group <%= @group_to_set %>
@@ -62,23 +62,23 @@ user <%= @user %>
 log-append <%= @logfile %>
 <% end -%>
 status <%= @status_log %>
-<% if @status_version != '' -%>
+<% if @status_version -%>
 status-version <%= @status_version %>
 <% end -%>
 dev <%= @dev %>
-<% if @local != '' -%>
+<% if @local -%>
 local <%= @local %>
 <% end -%>
 <% if @ipp -%>
 ifconfig-pool-persist <%= @name %>/vpn-ipp.txt
 <% end -%>
-<% if @server != '' -%>
+<% if @server -%>
 server <%= @server %>
 <% end -%>
-<% if @server_ipv6 != '' -%>
+<% if @server_ipv6 -%>
 server-ipv6 <%= @server_ipv6 %>
 <% end -%>
-<% if @server_bridge != '' -%>
+<% if @server_bridge -%>
 server-bridge <%= @server_bridge %>
 <% end -%>
 <% @push.each do |item| -%>
@@ -96,16 +96,16 @@ sndbuf <%= @sndbuf %>
 <% if @rcvbuf -%>
 rcvbuf <%= @rcvbuf %>
 <% end -%>
-<% if @keepalive != '' -%>
+<% if @keepalive -%>
 keepalive <%= @keepalive %>
 <% end -%>
-<% if @topology != '' -%>
+<% if @topology -%>
 topology <%= @topology %>
 <% end -%>
-<% if @verb != '' -%>
+<% if @verb -%>
 verb <%= @verb %>
 <% end -%>
-<% if @cipher != '' -%>
+<% if @cipher -%>
 cipher <%= @cipher %>
 <% end -%>
 <% if @tls_cipher -%>
@@ -132,13 +132,13 @@ plugin <%= @pam_module_path %> "<%= @pam_module_arguments %>"
 <% if @management -%>
 management <%= @management_ip %> <%= @management_port %>
 <% end -%>
-<% if @up != '' or @down != ''-%>
+<% if @up or @down -%>
 script-security 2
 <% end -%>
-<% if @up != '' -%>
+<% if @up -%>
 up "<%= @up %>"
 <% end -%>
-<% if @down != '' -%>
+<% if @down -%>
 down "<%= @down %>"
 <% end -%>
 <% if @username_as_common_name -%>

--- a/templates/vars.erb
+++ b/templates/vars.erb
@@ -66,12 +66,12 @@ export KEY_PROVINCE="<%= @province %>"
 export KEY_CITY="<%= @city %>"
 export KEY_ORG="<%= @organization %>"
 export KEY_EMAIL="<%= @email %>"
-<% if @key_cn != '' -%>
+<% if @key_cn -%>
 export KEY_CN="<%= @key_cn %>"
 <% end -%>
-<% if @key_name != '' -%>
+<% if @key_name -%>
 export KEY_NAME="<%= @key_name %>"
 <% end -%>
-<% if @key_ou != '' -%>
+<% if @key_ou -%>
 export KEY_OU="<%= @key_ou %>"
 <% end -%>

--- a/vagrant/server.pp
+++ b/vagrant/server.pp
@@ -5,7 +5,7 @@ node default {
     city         => 'Winterthur',
     organization => 'example.org',
     email        => 'root@example.org',
-    server       => '10.200.200.0 255.255.255.0'
+    server       => '10.200.200.0 255.255.255.0',
   }
 
   openvpn::client { 'client1':
@@ -14,7 +14,7 @@ node default {
 
   openvpn::client_specific_config { 'client1':
     server   => 'winterthur',
-    ifconfig => '10.200.200.100 255.255.255.0'
+    ifconfig => '10.200.200.100 255.255.255.0',
   }
 
   openvpn::client { 'client2':


### PR DESCRIPTION
The following change adds in support for the changed path and filename for the PAM module. This can be used if you have PAM already configured to support LDAP rather than hitting up LDAP directly (ie UsePAM => true, rather than UseLDAP => true). ie this is another way of tackling the problems raised in #172