### PR TITLE
Added ldap support for Redhat/Centos 7 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,8 +28,8 @@ class openvpn::params {
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
-        $additional_packages = ['easy-rsa']
-        $ldap_auth_plugin_location = undef
+        $additional_packages = ['easy-rsa', 'openvpn-auth-ldap']
+        $ldap_auth_plugin_location = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so'
         $systemd = true
       # Redhat/Centos == 6.0
       } elsif(versioncmp($::operatingsystemrelease, '6.0') >= 0) and $::operatingsystem != 'Amazon' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class openvpn::params {
 
       # Redhat/Centos >= 7.0
       if(versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
-        $additional_packages = ['easy-rsa', 'openvpn-auth-ldap']
+        $additional_packages = ['easy-rsa','openvpn-auth-ldap']
         $ldap_auth_plugin_location = '/usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so'
         $systemd = true
       # Redhat/Centos == 6.0


### PR DESCRIPTION
ldap plugin path added (was undef in params)
package "openvpn-auth-ldap" added. 
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
