### PR TITLE
Allow to define remote-cert-tls

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -226,7 +226,7 @@ define openvpn::client (
   Optional[String] $readme                    = undef,
   Boolean $pull                               = false,
   Boolean $server_extca_enabled               = false,
-  Boolean $ns_cert_type                       = false,
+  Boolean $ns_cert_type                       = true,
   Boolean $remote_cert_tls                    = false,
 ) {
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -150,6 +150,15 @@
 #            Use this in Combination with exported_ressourced, since they don't have Access to the Serverconfig
 #   Default: false
 #
+# [*ns_cert_type*]
+#   Boolean. Enable or disable use of ns-cert-type.
+#   Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
+#   Default: true
+#
+# [*remote_cert_tls*]
+#   Boolean. Enable or disable use of remote-cert-tls
+#   used with client configuration
+#   Default: false
 # === Examples
 #
 #   openvpn::client {
@@ -216,7 +225,9 @@ define openvpn::client (
   Optional[Integer] $expire                   = undef,
   Optional[String] $readme                    = undef,
   Boolean $pull                               = false,
-  Boolean $server_extca_enabled               = false
+  Boolean $server_extca_enabled               = false,
+  Boolean $ns_cert_type                       = false,
+  Boolean $remote_cert_tls                    = false,
 ) {
 
   if $pam {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -387,7 +387,13 @@
 # [*ns_cert_type*]
 #   Boolean. Enable or disable use of ns-cert-type for the session. Generally
 #   used with client configuration
+#   Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
 #   Default: true
+#
+# [*remote_cert_tls*]
+#   Boolean. Enable or disable use of remote-cert-tls for the session. Generally
+#   used with client configuration
+#   Default: false
 #
 # [*nobind*]
 #   Boolean. Whether or not to bind to a specific port number.
@@ -523,6 +529,7 @@ define openvpn::server (
   Optional[String] $extca_tls_auth_key_file = undef,
   Optional[Boolean] $autostart              = undef,
   Boolean $ns_cert_type                     = true,
+  Boolean $remote_cert_tls                  = false,
   Boolean $nobind                           = false,
   Optional[String] $secret                  = undef,
   Hash $custom_options                      = {},

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -97,7 +97,9 @@ describe 'openvpn::client', type: :define do
         'sndbuf'                => 393_216,
         'rcvbuf'                => 393_215,
         'readme'                => 'readme text',
-        'pull'                  => true
+        'pull'                  => true,
+        'ns_cert_type'          => false,
+        'remote_cert_tls'       => true,
       }
     end
     let(:facts) do
@@ -133,6 +135,7 @@ describe 'openvpn::client', type: :define do
     it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^rcvbuf\s+393215$}) }
     it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/README').with_content(%r{^readme text$}) }
     it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^pull$}) }
+    it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote-cert-tls\s+server$}) }
   end
 
   context 'omitting the cipher key' do

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -99,7 +99,7 @@ describe 'openvpn::client', type: :define do
         'readme'                => 'readme text',
         'pull'                  => true,
         'ns_cert_type'          => false,
-        'remote_cert_tls'       => true,
+        'remote_cert_tls'       => true
       }
     end
     let(:facts) do

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -181,7 +181,8 @@ describe 'openvpn::server', type: :define do
         'fragment'        => 1412,
         'custom_options'  => { 'this' => 'that' },
         'portshare'       => '127.0.0.1 8443',
-        'secret'          => 'secretsecret1234'
+        'secret'          => 'secretsecret1234',
+        'remote_cert_tls' => true,
       }
     end
 
@@ -247,6 +248,7 @@ describe 'openvpn::server', type: :define do
     it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ping-timer-rem}) }
     it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^sndbuf}) }
     it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^rcvbuf}) }
+    it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^remote-cert-tls server$}) }
 
     it { is_expected.to contain_file('/etc/openvpn/test_server/keys/pre-shared.secret').with_content(%r{^secretsecret1234$}).with(ensure: 'present') }
     it { is_expected.to contain_schedule('renew crl.pem schedule on test_server') }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -182,7 +182,7 @@ describe 'openvpn::server', type: :define do
         'custom_options'  => { 'this' => 'that' },
         'portshare'       => '127.0.0.1 8443',
         'secret'          => 'secretsecret1234',
-        'remote_cert_tls' => true,
+        'remote_cert_tls' => true
       }
     end
 

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -31,7 +31,11 @@ tls-cipher <%= @tls_cipher %>
 <% if @mute_replay_warnings -%>
 mute-replay-warnings
 <% end -%>
+<% if @ns_cert_type -%>
 ns-cert-type server
+<% elsif @remote_cert_tls -%>
+remote-cert-tls server
+<% end -%>
 <% if @sndbuf -%>
 sndbuf <%= @sndbuf %>
 <% end -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -5,6 +5,8 @@ client-config-dir <%= @etc_directory -%>/openvpn/<%= @name %>/client-configs
 client
 <% if @ns_cert_type -%>
 ns-cert-type server
+<% elsif @remote_cert_tls -%>
+remote-cert-tls server
 <% end -%>
 <% @remote.to_a.each do |rem| -%>
 remote <%= rem %>


### PR DESCRIPTION
https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--ns-cert-type

`ns-cert-type` is deprecated in OpenVPN and will removed in the next version of OpenVPN.

The PR adds an opt-in for the backwards compatibility to use the new option.