### PR TITLE
Bug Fix: Ensure cipher and tls_cipher can be disabled entirely

### DIFF
--- a/templates/client.erb
+++ b/templates/client.erb
@@ -22,10 +22,10 @@ persist-key
 <% if @persist_tun -%>
 persist-tun
 <% end -%>
-<% if @cipher -%>
+<% if @cipher != '' -%>
 cipher <%= @cipher %>
 <% end -%>
-<% if @tls_cipher -%>
+<% if @tls_cipher != '' -%>
 tls-cipher <%= @tls_cipher %>
 <% end -%>
 <% if @mute_replay_warnings -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -110,7 +110,7 @@ verb <%= @verb %>
 <% if @cipher != '' -%>
 cipher <%= @cipher %>
 <% end -%>
-<% if @tls_cipher -%>
+<% if @tls_cipher != '' -%>
 tls-cipher <%= @tls_cipher %>
 <% end -%>
 <% if @c2c -%>


### PR DESCRIPTION
This change ensures that by setting cipher and tls_cipher to blank strings, they are consistently kept out of the configuration files - as opposed to invalid configuration being generated where the config keyword is generated with a blank argument.

Note that this does not change any defaults, since the Puppet module sets cipher and tls_cipher by default. Booleans can't be used, since we validate that these arguments are strings and boolean false is not a string :-)