### PR TITLE
Changed type for port in class documentation

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,7 +76,7 @@
 #   Options: false (syslog) or log file name
 #
 # [*port*]
-#   Integer.  The port the openvpn server service is running on
+#   String.  The port the openvpn server service is running on
 #   Default: 1194
 #
 # [*portshare*]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
The documentation does not match the actual code. I decided to change the documentation since that would have the least impact on existing installations.

Closes https://github.com/voxpupuli/puppet-openvpn/issues/272