### PR TITLE
Do not require openvpn::client for client specific configs

### DIFF
--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -88,7 +88,6 @@ define openvpn::client_specific_config (
 ) {
 
   Openvpn::Server[$server]
-  -> Openvpn::Client[$name]
   -> Openvpn::Client_specific_config[$name]
 
   file { "${::openvpn::params::etc_directory}/openvpn/${server}/client-configs/${name}":

--- a/spec/defines/openvpn_client_specific_config_spec.rb
+++ b/spec/defines/openvpn_client_specific_config_spec.rb
@@ -13,18 +13,13 @@ describe 'openvpn::client_specific_config', type: :define do
     }
   end
   let(:pre_condition) do
-    [
       'openvpn::server { "test_server":
         country       => "CO",
         province      => "ST",
         city          => "Some City",
         organization  => "example.org",
         email         => "testemail@example.org"
-      }',
-      'openvpn::client { "test_client":
-        server => "test_server"
       }'
-    ].join
   end
 
   it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client') }


### PR DESCRIPTION
There is no need to require openvpn::client type as client configs
don't rely on  any of that type resources. It also not possible to use
client_specific_config if extca_enabled is set to true for a server due
to openvpn::client failure.

Fixes #229

Signed-off-by: Anton Baranov <abaranov@linuxfoundation.org>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
