### PR TITLE
move concat version_requirement to >= 3.0.0 < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION

#### Pull Request (PR) description

To fix broken modules dependencies management . 
With current settings in `metadata.json` a fresh install get the following error message : 
```
Error: Could not install module 'puppetlabs-concat' (???)
  	  No version of 'puppetlabs-concat' can satisfy all dependencies
  	    Use `puppet module install --ignore-dependencies` to install only this module
```
#### This Pull Request (PR) fixes the following issues

It will permit to merge the PR #292 
