### PR TITLE
FreeBSD: change additional_packages to easy-rsa2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,7 +103,7 @@ class openvpn::params {
       $group               = 'nogroup'
       $link_openssl_cnf    = true
       $pam_module_path     = '/usr/local/lib/openvpn/openvpn-auth-pam.so'
-      $additional_packages = ['easy-rsa']
+      $additional_packages = ['easy-rsa2']
       $easyrsa_source      = '/usr/local/share/easy-rsa'
       $default_easyrsa_ver = '2.0'
       $namespecific_rclink = true


### PR DESCRIPTION
the default easy-rsa package in FreeBSD gets easy-rsa 3.0.5
which for some reason does not work correctly in puppet-openvpn
under FreeBSD platform ( of course with changed $default_easyrsa_ver )
Therefore, temporarily specify the correct easy-rsa 2x package name
for FreeBSD: https://www.freshports.org/security/easy-rsa2/

I will try to look soon for easy-rsa 3.0.5 and puppet-openvpn error
with FreeBSD platform.

Tested on:
  FreeBSD 11
  FreeBSD 12
  ( Puppet client: puppet5-5.5.6, Puppet server: 5.3.5 )

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
