### PR TITLE
Set DH timeout to accommodate low performance CPU

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -92,7 +92,7 @@ define openvpn::ca (
 
       exec { "generate dh param ${name}":
         command  => '. ./vars && ./clean-all && ./build-dh',
-        timeout  => 1800,
+        timeout  => 20000,
         cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
         creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/dh${ssl_key_size}.pem",
         provider => 'shell',
@@ -166,6 +166,7 @@ define openvpn::ca (
 
       exec { "generate dh param ${name}":
         command  => './easyrsa --batch gen-dh',
+        timeout  => 20000,
         cwd      => "${etc_directory}/openvpn/${name}/easy-rsa",
         creates  => "${etc_directory}/openvpn/${name}/easy-rsa/keys/dh.pem",
         provider => 'shell',


### PR DESCRIPTION
#### Set DH timeout to accommodate computers with a low performance CPU
On a Raspberry Pi B+ the Diffie-Hellman  parameter generation for
a 2048 key was measured to take 229m45.379s wall clock time.
Set the respective command's timeout 50% above this, to prevent
the corresponding rule from timing out.

#### This Pull Request (PR) fixes the following issues
Fixes #316