### PR TITLE
consider the easyrsa version to trigger the renew crl command

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -330,11 +330,26 @@ define openvpn::server (
           period => $crl_renew_schedule_period,
           repeat => $crl_renew_schedule_repeat,
         }
-        exec { "renew crl.pem on ${name}":
-          command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${openvpn::etc_directory}/openvpn/${name}/crl.pem -config ${openvpn::etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
-          cwd      => "${openvpn::etc_directory}/openvpn/${name}/easy-rsa",
-          provider => 'shell',
-          schedule => "renew crl.pem schedule on ${name}",
+        case $openvpn::easyrsa_version {
+          '2.0': {
+            exec { "renew crl.pem on ${name}":
+              command  => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${openvpn::etc_directory}/openvpn/${name}/crl.pem -config ${openvpn::etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+              cwd      => "${openvpn::etc_directory}/openvpn/${name}/easy-rsa",
+              provider => 'shell',
+              schedule => "renew crl.pem schedule on ${name}",
+            }
+          }
+          '3.0': {
+            exec { "renew crl.pem on ${name}":
+              command  => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${etc_directory}/openvpn/${name}/crl.pem -config ${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+              cwd      => "${openvpn::etc_directory}/openvpn/${name}/easy-rsa",
+              provider => 'shell',
+              schedule => "renew crl.pem schedule on ${name}",
+            }
+          }
+          default: {
+            fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0.")
+          }
         }
       }
     } elsif !$extca_enabled {

--- a/spec/acceptance/openvpn_spec.rb
+++ b/spec/acceptance/openvpn_spec.rb
@@ -6,11 +6,13 @@ when 'RedHat'
   key_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys/private'
   crt_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys/issued'
   index_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys'
+  renew_crl_cmd = "cd /etc/openvpn/test_openvpn_server/easy-rsa && . ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out /etc/openvpn/test_openvpn_server/crl.pem -config /etc/openvpn/test_openvpn_server/easy-rsa/openssl.cnf"
 when 'Debian'
   server_crt = '/etc/openvpn/test_openvpn_server/easy-rsa/keys/server.crt'
   key_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys'
   crt_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys'
   index_path = '/etc/openvpn/test_openvpn_server/easy-rsa/keys'
+  renew_crl_cmd = "cd /etc/openvpn/test_openvpn_server/easy-rsa && . ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out /etc/openvpn/test_openvpn_server/crl.pem -config /etc/openvpn/test_openvpn_server/easy-rsa/openssl.cnf"
 end
 
 # All-terrain tls ciphers are used to be able to work with all supported OSes.
@@ -121,6 +123,10 @@ describe 'server defined type' do
 
     describe command('echo status |nc -w 1 localhost 7505') do
       its(:stdout) { is_expected.to match %r{.*vpnclienta.*} }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+
+    describe command(renew_crl_cmd.to_s) do
       its(:exit_status) { is_expected.to eq 0 }
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

when the custom fact was created to distinguish easyrsa version, it was not considered for triggering adapted command when crl is renewed.

#### This Pull Request (PR) fixes the following issues

Fixes #318 