### PR TITLE
Use stdlib functions for hash key discovery

### DIFF
--- a/manifests/deploy/export.pp
+++ b/manifests/deploy/export.pp
@@ -18,8 +18,8 @@ define openvpn::deploy::export (
   -> Openvpn::Client[$name]
   -> Openvpn::Deploy::Export[$name]
 
-  if $facts['openvpn'] {
-    if $facts['openvpn'][$server][$name] {
+  if has_key($facts, 'openvpn') {
+    if dig44($facts, ['openvpn', $server, $name], false) {
       $data = $facts['openvpn'][$server][$name]
 
       @@file { "exported-${server}-${name}-config":

--- a/manifests/deploy/export.pp
+++ b/manifests/deploy/export.pp
@@ -18,63 +18,59 @@ define openvpn::deploy::export (
   -> Openvpn::Client[$name]
   -> Openvpn::Deploy::Export[$name]
 
-  if has_key($facts, 'openvpn') {
-    if dig44($facts, ['openvpn', $server, $name], false) {
-      $data = $facts['openvpn'][$server][$name]
+  if fact("openvpn.${server}.${name}") {
+    $data = $facts['openvpn'][$server][$name]
 
-      @@file { "exported-${server}-${name}-config":
+    @@file { "exported-${server}-${name}-config":
+      ensure  => file,
+      path    => "${openvpn::etc_directory}/openvpn/${name}.conf",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => $data['conf'],
+      tag     => "${server}-${name}",
+    }
+
+    @@file { "exported-${server}-${name}-ca":
+      ensure  => file,
+      path    => "${openvpn::etc_directory}/openvpn/keys/${name}/ca.crt",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => $data['ca'],
+      tag     => "${server}-${name}",
+    }
+
+    @@file { "exported-${server}-${name}-crt":
+      ensure  => file,
+      path    => "${openvpn::etc_directory}/openvpn/keys/${name}/${name}.crt",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => $data['crt'],
+      tag     => "${server}-${name}",
+    }
+
+    @@file { "exported-${server}-${name}-key":
+      ensure  => file,
+      path    => "${openvpn::etc_directory}/openvpn/keys/${name}/${name}.key",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => $data['key'],
+      tag     => "${server}-${name}",
+    }
+
+    if $tls_auth {
+      @@file { "exported-${server}-${name}-ta":
         ensure  => file,
-        path    => "${openvpn::etc_directory}/openvpn/${name}.conf",
+        path    => "${openvpn::etc_directory}/openvpn/keys/${name}/ta.key",
         owner   => 'root',
         group   => 'root',
         mode    => '0600',
-        content => $data['conf'],
+        content => $data['ta'],
         tag     => "${server}-${name}",
-      }
-
-      @@file { "exported-${server}-${name}-ca":
-        ensure  => file,
-        path    => "${openvpn::etc_directory}/openvpn/keys/${name}/ca.crt",
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-        content => $data['ca'],
-        tag     => "${server}-${name}",
-      }
-
-      @@file { "exported-${server}-${name}-crt":
-        ensure  => file,
-        path    => "${openvpn::etc_directory}/openvpn/keys/${name}/${name}.crt",
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-        content => $data['crt'],
-        tag     => "${server}-${name}",
-      }
-
-      @@file { "exported-${server}-${name}-key":
-        ensure  => file,
-        path    => "${openvpn::etc_directory}/openvpn/keys/${name}/${name}.key",
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0600',
-        content => $data['key'],
-        tag     => "${server}-${name}",
-      }
-
-      if $tls_auth {
-        @@file { "exported-${server}-${name}-ta":
-          ensure  => file,
-          path    => "${openvpn::etc_directory}/openvpn/keys/${name}/ta.key",
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0600',
-          content => $data['ta'],
-          tag     => "${server}-${name}",
-        }
       }
     }
-  } else {
-    fail('openvpn not defined, is pluginsync enabled?')
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

When fiddling around with server names in the configuration, you'd have
to do a clean sweep of the whole configuration to ensure that there are
no problems with the fact existence and the ordering.

Using dig (and has_key for compatibility reasons to not change anything
front-facing), we can avoid this problem.