### PR TITLE
Allow 4 and 6 suffix inside proto to limit ip4 or ip6 connection only.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -136,7 +136,7 @@ define openvpn::server (
   Variant[Boolean, String] $logfile                                 = false,
   String $port                                                      = '1194',
   Optional[String] $portshare                                       = undef,
-  Enum['tcp', 'udp'] $proto                                         = 'tcp',
+  Enum['tcp', 'tcp4', 'tcp6', 'udp', 'udp4', 'udp6'] $proto         = 'tcp',
   Enum['1', '2', '3', ''] $status_version                           = '',
   String $status_log                                                = "/var/log/openvpn/${name}-status.log",
   String $server                                                    = '',

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -110,6 +110,81 @@ describe 'openvpn::server' do
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^rcvbuf\s+393215$}) }
       end
 
+      context 'when using udp4' do
+        let(:params) do
+          {
+            'country'       => 'CO',
+            'province'      => 'ST',
+            'city'          => 'Some City',
+            'organization'  => 'example.org',
+            'email'         => 'testemail@example.org',
+            'proto'         => 'udp4'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp4$}) }
+      end
+
+      context 'when using udp6' do
+        let(:params) do
+          {
+            'country'       => 'CO',
+            'province'      => 'ST',
+            'city'          => 'Some City',
+            'organization'  => 'example.org',
+            'email'         => 'testemail@example.org',
+            'proto'         => 'udp6'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp6$}) }
+      end
+
+      context 'when using tcp4' do
+        let(:params) do
+          {
+            'country'       => 'CO',
+            'province'      => 'ST',
+            'city'          => 'Some City',
+            'organization'  => 'example.org',
+            'email'         => 'testemail@example.org',
+            'proto'         => 'tcp4'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tcp4-server$}) }
+      end
+
+      context 'when using tcp6' do
+        let(:params) do
+          {
+            'country'       => 'CO',
+            'province'      => 'ST',
+            'city'          => 'Some City',
+            'organization'  => 'example.org',
+            'email'         => 'testemail@example.org',
+            'proto'         => 'tcp6'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tcp6-server$}) }
+      end
+
+      context 'when using invalid value for proto' do
+        let(:params) do
+          {
+            'country'       => 'CO',
+            'province'      => 'ST',
+            'city'          => 'Some City',
+            'organization'  => 'example.org',
+            'email'         => 'testemail@example.org',
+            'proto'         => 'tcp5'
+          }
+        end
+
+        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+      end
+
       context 'creating a server in client mode' do
         let(:title) { 'test_client' }
         let(:nobind) { false }

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -46,7 +46,7 @@ dh <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/dh.pem
 crl-verify <%= @etc_directory -%>/openvpn/<%= @ca_name %>/crl.pem
 <%   end -%>
 <% end -%>
-<% if @proto == 'tcp' -%>
+<% if @proto.include?('tcp') -%>
 proto <%= @proto %>-server
 <% else -%>
 proto <%= @proto %>


### PR DESCRIPTION
#### Pull Request (PR) description
Since 8.0.0 it's not possible to choose `tcp4` or `tcp6` as `proto` for an openvpn server.

#### This Pull Request (PR) fixes the following issues
N/A