### PR TITLE
Revoke command missing on easy-rsa 3.0 #331

### DIFF
--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -25,10 +25,40 @@ define openvpn::revoke (
 
   $etc_directory = $openvpn::etc_directory
 
-  exec { "revoke certificate for ${name} in context of ${server}":
-    command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
-    cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
-    provider => 'shell',
+  case $openvpn::easyrsa_version {
+    '2.0': {
+      exec { "revoke certificate for ${name} in context of ${server}":
+        command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+        cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
+        creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
+        provider => 'shell',
+      }
+    }
+    '3.0': {
+      # if $openvpn::manage_service {
+      #   if $facts['service_provider'] == 'systemd' {
+      #     $lnotify = Service["openvpn@${name}"]
+      #   } elsif $openvpn::namespecific_rclink {
+      #     $lnotify = Service["openvpn_${name}"]
+      #   } else {
+      #     $lnotify = Service['openvpn']
+      #     Openvpn::Server[$name] -> Service['openvpn']
+      #   }
+      # }
+      # else {
+      #   $lnotify = undef
+      # }
+
+      exec { "revoke certificate for ${name} in context of ${server}":
+        command  => ". ./vars && echo yes | ./easyrsa revoke ${name} 2>&1 | grep -E 'Already revoked|was successful|not a valid certificate' && ./easyrsa gen-crl && /bin/cp -f keys/crl.pem ../crl.pem && touch revoked/${name}",
+        cwd      => "/etc/openvpn/${server}/easy-rsa",
+        creates  => "/etc/openvpn/${server}/easy-rsa/revoked/${name}",
+        provider => 'shell',
+        # notify   => $lnotify,
+      }
+    }
+    default: {
+      fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0.")
+    }
   }
 }


### PR DESCRIPTION
https://github.com/voxpupuli/puppet-openvpn/issues/331

This block of code works for me.
```
 each($revoked) |$name| {
    exec { "revoke certificate for ${name} in context of ${server}":
      command  => ". ./vars && echo yes | ./easyrsa revoke ${name} 2>&1 | grep -E 'Already revoked|was successful|not a valid certificate' && ./easyrsa gen-crl && /bin/cp -f keys/crl.pem ../crl.pem && touch revoked/${name}",
      cwd      => "/etc/openvpn/${server}/easy-rsa",
      creates  => "/etc/openvpn/${server}/easy-rsa/revoked/${name}",
      provider => 'shell',
      notify   => Service["openvpn@${server}"]
    }
  }
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
