### PR TITLE
Adjust clients $compression type to match servers

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -45,7 +45,7 @@
 #
 define openvpn::client (
   String $server,
-  Enum['comp-lzo', ''] $compression                    = 'comp-lzo',
+  String $compression                                  = 'comp-lzo',
   Enum['tap', 'tun'] $dev                              = 'tun',
   Integer $mute                                        = 20,
   Boolean $mute_replay_warnings                        = true,

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -99,7 +99,7 @@ describe 'openvpn::client', type: :define do
         let(:params) do
           {
             'server'                => 'test_server',
-            'compression'           => 'comp-lzo',
+            'compression'           => 'compress lz4',
             'dev'                   => 'tap',
             'mute'                  => 10,
             'mute_replay_warnings'  => false,
@@ -135,7 +135,7 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^proto\s+udp$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote\s+somewhere\s+123$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote\s+galaxy\s+123$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^comp-lzo$}) }
+        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^compress lz4$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^resolv-retry\s+2m$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^verb\s+1$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^mute\s+10$}) }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -241,7 +241,7 @@ describe 'openvpn::server' do
             'city'            => 'Some City',
             'organization'    => 'example.org',
             'email'           => 'testemail@example.org',
-            'compression'     => 'fake_compression',
+            'compression'     => 'compress lz4',
             'port'            => '123',
             'proto'           => 'udp',
             'group'           => 'someone',
@@ -293,7 +293,7 @@ describe 'openvpn::server' do
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp$}) }
         it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tls-server$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^port\s+123$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^fake_compression$}) }
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^compress lz4$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+someone$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+someone$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^log\-append\s+/var/log/openvpn/test_server\.log$}) }
@@ -377,7 +377,7 @@ describe 'openvpn::server' do
               'city'            => 'Some City',
               'organization'    => 'example.org',
               'email'           => 'testemail@example.org',
-              'compression'     => 'fake_compression',
+              'compression'     => 'compress lz4',
               'port'            => '123',
               'proto'           => 'udp',
               'group'           => 'someone',
@@ -683,7 +683,7 @@ describe 'openvpn::server' do
               'city'            => 'Some City',
               'organization'    => 'example.org',
               'email'           => 'testemail@example.org',
-              'compression'     => 'fake_compression',
+              'compression'     => 'compress lz4',
               'port'            => '123',
               'proto'           => 'udp',
               'group'           => 'someone',


### PR DESCRIPTION
Allow newer compress option at client config since comp-lzo is deprecated

https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--comp-lzo