### PR TITLE
Fix client cert revoke error with easyrsa 3.0

### DIFF
--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -42,13 +42,16 @@ define openvpn::revoke (
         provider => 'shell',
       }
     }
-    default: {
+    '2.0': {
       exec { "revoke certificate for ${name} in context of ${server}":
         command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
         cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
         creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
         provider => 'shell',
       }
+    }
+    default: {
+      fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0.")
     }
   }
 }

--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -25,10 +25,30 @@ define openvpn::revoke (
 
   $etc_directory = $openvpn::etc_directory
 
-  exec { "revoke certificate for ${name} in context of ${server}":
-    command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
-    cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
-    provider => 'shell',
+  case $openvpn::easyrsa_version {
+    '3.0': {
+      exec { "revoke certificate for ${name} in context of ${server}":
+        command  => ". ./vars && ./easyrsa --batch revoke ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2|))' && touch revoked/${name}",
+        cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
+        creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
+        provider => 'shell',
+      }
+      # `easyrsa gen-crl` does not work, since it will create the crl.pem
+      # to keys/crl.pem which is a symlinked to crl.pem in the servers etc
+      # directory
+      exec { "renew crl.pem for ${name}":
+        command  => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ../crl.pem -config ./openssl.cnf",
+        cwd      => "${openvpn::etc_directory}/openvpn/${server}/easy-rsa",
+        provider => 'shell',
+      }
+    }
+    default: {
+      exec { "revoke certificate for ${name} in context of ${server}":
+        command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+        cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
+        creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
+        provider => 'shell',
+      }
+    }
   }
 }

--- a/spec/acceptance/openvpn_spec.rb
+++ b/spec/acceptance/openvpn_spec.rb
@@ -36,6 +36,7 @@ describe 'server defined type' do
       apply_manifest_on(hosts_as('vpnserver'), pp, catch_failures: true)
       apply_manifest_on(hosts_as('vpnserver'), pp, catch_changes: true)
     end
+
     it 'creates openvpn client certificate idempotently' do
       pp = %(
         openvpn::server { 'test_openvpn_server':
@@ -56,7 +57,18 @@ describe 'server defined type' do
           remote_host => $facts['networking']['ip'],
           tls_cipher  => 'TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA',
         }
-      )
+
+  openvpn::client { 'vpnclientb' :
+          server      => 'test_openvpn_server',
+          require     => Openvpn::Server['test_openvpn_server'],
+          remote_host => $facts['networking']['ip'],
+          tls_cipher  => 'TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA',
+        }
+
+  openvpn::revoke { 'vpnclientb' :
+          server      => 'test_openvpn_server',
+        }
+       )
       apply_manifest_on(hosts_as('vpnserver'), pp, catch_failures: true)
       apply_manifest_on(hosts_as('vpnserver'), pp, catch_changes: true)
     end

--- a/spec/defines/openvpn_revoke_spec.rb
+++ b/spec/defines/openvpn_revoke_spec.rb
@@ -24,12 +24,33 @@ describe 'openvpn::revoke', type: :define do
       let(:params) { { 'server' => 'test_server' } }
 
       it { is_expected.to compile.with_all_deps }
+      context 'easyrsa version 2.0' do
+        let(:facts) do
+          super().merge('easyrsa' => '2.0')
+        end
 
-      it {
-        is_expected.to contain_exec('revoke certificate for test_client in context of test_server').with(
-          'command' => ". ./vars && ./revoke-full test_client; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/test_client"
-        )
-      }
+        it {
+          is_expected.to contain_exec('revoke certificate for test_client in context of test_server').with(
+            'command' => ". ./vars && ./revoke-full test_client; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/test_client"
+          )
+        }
+      end
+      context 'easyrsa version 3.0' do
+        let(:facts) do
+          super().merge('easyrsa' => '3.0')
+        end
+
+        it {
+          is_expected.to contain_exec('revoke certificate for test_client in context of test_server').with(
+            'command' => ". ./vars && ./easyrsa --batch revoke test_client; echo \"exit $?\" | grep -qE '(error 23|exit (0|2|))' && touch revoked/test_client"
+          )
+        }
+        it {
+          is_expected.to contain_exec('renew crl.pem for test_client').with(
+            'command' => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ../crl.pem -config ./openssl.cnf"
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
In easyrsa 3.0 (used in CentOS) the command has changed. Now there is
only a single binary to run the scripts. Further the generation of CRL
also has changed; now a new crl.pem file is created in keys/crl.pem
which overrides the symlink there. So the revocation check did not work
anymore, because the crl.pem in the base directory was not checked when
a client connected.

Resolves: VSHNOPS-1537

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
