### PR TITLE
Add scripts with server

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -339,6 +339,14 @@ Determins if a tls key is generated
 
 Default value: `false`
 
+##### `tls_static_key`
+
+Data type: `Boolean`
+
+Determins if a tls key is generated
+
+Default value: `false`
+
 ##### `crl_days`
 
 Data type: `Integer`
@@ -375,7 +383,7 @@ Name of the corresponding openvpn endpoint
 
 ##### `compression`
 
-Data type: `Enum['comp-lzo', '']`
+Data type: `String`
 
 Which compression algorithim to use
 
@@ -514,6 +522,14 @@ Default value: `false`
 Data type: `Boolean`
 
 Activates tls-auth to Add an additional layer of HMAC authentication on top of the TLS control channel to protect against DoS attacks. This has to be set to the same value as on the Server
+
+Default value: `false`
+
+##### `tls_crypt`
+
+Data type: `Boolean`
+
+Encrypt and authenticate all control channel packets with the key from keyfile. (See --tls-auth for more background.)
 
 Default value: `false`
 
@@ -662,13 +678,13 @@ The following parameters are available in the `openvpn::client_specific_config` 
 
 ##### `server`
 
-Data type: `String`
+Data type: `String[1]`
 
 Name of the corresponding openvpn endpoint
 
 ##### `iroute`
 
-Data type: `Array[String]`
+Data type: `Array[String[1]]`
 
 Array of iroute combinations.
 
@@ -676,7 +692,7 @@ Default value: []
 
 ##### `iroute_ipv6`
 
-Data type: `Array[String]`
+Data type: `Array[String[1]]`
 
 Array of IPv6 iroute combinations.
 
@@ -684,7 +700,7 @@ Default value: []
 
 ##### `route`
 
-Data type: `Array[String]`
+Data type: `Array[String[1]]`
 
 Array of route combinations pushed to client.
 
@@ -692,15 +708,23 @@ Default value: []
 
 ##### `ifconfig`
 
-Data type: `Variant[Boolean, String]`
+Data type: `Optional[String[1]]`
 
 IP configuration to push to the client.
 
-Default value: `false`
+Default value: `undef`
+
+##### `ifconfig_ipv6`
+
+Data type: `Optional[String[1]]`
+
+IPv6 configuration to push to the client.
+
+Default value: `undef`
 
 ##### `dhcp_options`
 
-Data type: `Array[String]`
+Data type: `Array[String[1]]`
 
 DHCP options to push to the client.
 
@@ -716,11 +740,19 @@ Default value: `false`
 
 ##### `ensure`
 
-Data type: `Enum[present, absent]`
+Data type: `Enum['present', 'absent']`
 
 Sets the client specific configuration file status (present or absent)
 
 Default value: present
+
+##### `manage_client_configs`
+
+Data type: `Boolean`
+
+Manage dependencies on Openvpn::Client ressources
+
+Default value: `true`
 
 ### openvpn::deploy::client
 
@@ -982,6 +1014,30 @@ Logfile for this openvpn server
 
 Default value: `false`
 
+##### `manage_logfile_directory`
+
+Data type: `Boolean`
+
+Manage the directory that the logfile is located in
+
+Default value: `false`
+
+##### `logdirectory_user`
+
+Data type: `String[1]`
+
+The owner user of the logfile directory
+
+Default value: 'nobody'
+
+##### `logdirectory_group`
+
+Data type: `String[1]`
+
+The owner group of the logfile directory
+
+Default value: 'nobody'
+
 ##### `port`
 
 Data type: `String`
@@ -1000,7 +1056,7 @@ Default value: `undef`
 
 ##### `proto`
 
-Data type: `Enum['tcp', 'udp']`
+Data type: `Enum['tcp', 'tcp4', 'tcp6', 'udp', 'udp4', 'udp6']`
 
 What IP protocol is being used.
 
@@ -1160,19 +1216,35 @@ Default value: 7505
 
 ##### `up`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Script which we want to run when openvpn server starts
+Script which we want to run when openvpn server starts. If the path to the scirpt does not contain a slash, it will be assumed to be in `openvpn/${name}/scripts` directory.
 
-Default value: ''
+Default value: `undef`
 
 ##### `down`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Script which we want to run when openvpn server stops
+Script which we want to run when openvpn server stops. If the path to the scirpt does not contain a slash, it will be assumed to be in `openvpn/${name}/scripts` directory.
 
-Default value: ''
+Default value: `undef`
+
+##### `client_connect`
+
+Data type: `Optional[String[1]]`
+
+Script which we want to run when a client connects. If the path to the scirpt does not contain a slash, it will be assumed to be in `openvpn/${name}/scripts` directory.
+
+Default value: `undef`
+
+##### `client_disconnect`
+
+Data type: `Optional[String[1]]`
+
+Script which we want to run when a client disconnects. If the path to the scirpt does not contain a slash, it will be assumed to be in `openvpn/${name}/scripts` directory.
+
+Default value: `undef`
 
 ##### `username_as_common_name`
 
@@ -1296,19 +1368,19 @@ Default value: ''
 
 ##### `ldap_tls_client_cert_file`
 
-Data type: `String`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 LDAP TLS authentication: path to the tls client certificate
 
-Default value: ''
+Default value: `undef`
 
 ##### `ldap_tls_client_key_file`
 
-Data type: `String`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 LDAP TLS authentication: path to the tls client key
 
-Default value: ''
+Default value: `undef`
 
 ##### `verb`
 
@@ -1395,6 +1467,14 @@ Default value: ''
 Data type: `Boolean`
 
 Activates tls-auth to Add an additional layer of HMAC authentication on top of the TLS control channel to protect against DoS attacks.
+
+Default value: `false`
+
+##### `tls_crypt`
+
+Data type: `Boolean`
+
+Encrypt and authenticate all control channel packets with the key from keyfile. (See --tls-auth for more background.)
 
 Default value: `false`
 
@@ -1581,6 +1661,26 @@ Data type: `Optional[String]`
 A pre-shared static key.
 
 Default value: `undef`
+
+##### `scripts`
+
+Data type: `Hash[String, Hash]`
+
+Hash of scripts to copy with this instance.
+For example, to put a script in `/etc/openvpn/test-site/scripts/add-tap-to-bridge.sh` and use it as an `up` script
+``` puppet
+openvpn::server { 'test-site':
+  ....
+  up => 'add-tap-to-bridge.sh',
+  scripts => {
+    "add-tap-to-bridge.sh" => {
+      source => 'puppet:///path/to/add-tap-to-bridge.sh',
+    },
+  },
+}
+```
+
+Default value: {}
 
 ##### `custom_options`
 

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -292,57 +292,59 @@ describe 'openvpn::server' do
       context 'creating a server setting all parameters' do
         let(:params) do
           {
-            'country' => 'CO',
-            'province'        => 'ST',
-            'city'            => 'Some City',
-            'organization'    => 'example.org',
-            'email'           => 'testemail@example.org',
-            'compression'     => 'compress lz4',
-            'port'            => '123',
-            'proto'           => 'udp',
-            'group'           => 'someone',
-            'user'            => 'someone',
-            'logfile'         => '/var/log/openvpn/server1/test_server.log',
+            'country'           => 'CO',
+            'province'          => 'ST',
+            'city'              => 'Some City',
+            'organization'      => 'example.org',
+            'email'             => 'testemail@example.org',
+            'compression'       => 'compress lz4',
+            'port'              => '123',
+            'proto'             => 'udp',
+            'group'             => 'someone',
+            'user'              => 'someone',
+            'logfile'           => '/var/log/openvpn/server1/test_server.log',
             'manage_logfile_directory' => true,
-            'logdirectory_user' => 'someone',
-            'logdirectory_group' => 'someone',
-            'status_log'      => '/tmp/test_server_status.log',
-            'dev'             => 'tun1',
-            'up'              => '/tmp/up',
-            'down'            => '/tmp/down',
-            'local'           => '2.3.4.5',
-            'ipp'             => true,
-            'server'          => '2.3.4.0 255.255.0.0',
+            'logdirectory_user'        => 'someone',
+            'logdirectory_group'       => 'someone',
+            'status_log'        => '/tmp/test_server_status.log',
+            'dev'               => 'tun1',
+            'up'                => '/tmp/up',
+            'down'              => '/tmp/down',
+            'client_connect'    => '/tmp/connect',
+            'client_disconnect' => '/tmp/disconnect',
+            'local'             => '2.3.4.5',
+            'ipp'               => true,
+            'server'            => '2.3.4.0 255.255.0.0',
             'server_ipv6'	=> 'fe80:1337:1337:1337::/64',
-            'push'            => ['dhcp-option DNS 172.31.0.30', 'route 172.31.0.0 255.255.0.0'],
-            'route'           => ['192.168.30.0 255.255.255.0', '192.168.35.0 255.255.0.0'],
-            'route_ipv6'      => ['2001:db8:1234::/64', '2001:db8:abcd::/64'],
-            'keepalive'       => '10 120',
-            'topology'        => 'subnet',
-            'ssl_key_size'    => 2048,
-            'management'      => true,
-            'management_ip'   => '1.3.3.7',
-            'management_port' => 1337,
-            'common_name'     => 'mylittlepony',
-            'ca_expire'       => 365,
-            'crl_auto_renew'  => true,
-            'key_expire'      => 365,
-            'key_cn'          => 'yolo',
-            'key_name'        => 'burp',
-            'key_ou'          => 'NSA',
-            'verb'            => 'mute',
-            'cipher'          => 'DES-CBC',
-            'tls_cipher'      => 'TLS-DHE-RSA-WITH-AES-256-CBC-SHA',
-            'persist_key'     => true,
-            'persist_tun'     => true,
-            'duplicate_cn'    => true,
-            'tls_auth'        => true,
-            'tls_server'      => true,
-            'fragment'        => 1412,
-            'custom_options'  => { 'this' => 'that' },
-            'portshare'       => '127.0.0.1 8443',
-            'secret'          => 'secretsecret1234',
-            'remote_cert_tls' => true
+            'push'              => ['dhcp-option DNS 172.31.0.30', 'route 172.31.0.0 255.255.0.0'],
+            'route'             => ['192.168.30.0 255.255.255.0', '192.168.35.0 255.255.0.0'],
+            'route_ipv6'        => ['2001:db8:1234::/64', '2001:db8:abcd::/64'],
+            'keepalive'         => '10 120',
+            'topology'          => 'subnet',
+            'ssl_key_size'      => 2048,
+            'management'        => true,
+            'management_ip'     => '1.3.3.7',
+            'management_port'   => 1337,
+            'common_name'       => 'mylittlepony',
+            'ca_expire'         => 365,
+            'crl_auto_renew'    => true,
+            'key_expire'        => 365,
+            'key_cn'            => 'yolo',
+            'key_name'          => 'burp',
+            'key_ou'            => 'NSA',
+            'verb'              => 'mute',
+            'cipher'            => 'DES-CBC',
+            'tls_cipher'        => 'TLS-DHE-RSA-WITH-AES-256-CBC-SHA',
+            'persist_key'       => true,
+            'persist_tun'       => true,
+            'duplicate_cn'      => true,
+            'tls_auth'          => true,
+            'tls_server'        => true,
+            'fragment'          => 1412,
+            'custom_options'    => { 'this' => 'that' },
+            'portshare'         => '127.0.0.1 8443',
+            'secret'            => 'secretsecret1234',
+            'remote_cert_tls'   => true
           }
         end
 
@@ -379,6 +381,8 @@ describe 'openvpn::server' do
 
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^up "/tmp/up"$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^down "/tmp/down"$}) }
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client-connect "/tmp/connect"$}) }
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client-disconnect "/tmp/disconnect"$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^script-security 2$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
@@ -617,12 +621,16 @@ describe 'openvpn::server' do
         context 'when pushing scripts' do
           let(:params) do
             {
-              'country'       => 'CO',
-              'province'      => 'ST',
-              'city'          => 'Some City',
-              'organization'  => 'example.org',
-              'email'         => 'testemail@example.org',
-              'scripts'       => {
+              'country'           => 'CO',
+              'province'          => 'ST',
+              'city'              => 'Some City',
+              'organization'      => 'example.org',
+              'email'             => 'testemail@example.org',
+              'up'                => 'up.sh',
+              'down'              => 'down.sh',
+              'client_connect'    => 'connect.sh',
+              'client_disconnect' => 'disconnect.sh',
+              'scripts'           => {
                 'add-tap-to-bridge.sh' => {
                   'ensure' => 'present'
                 }
@@ -631,6 +639,28 @@ describe 'openvpn::server' do
           end
 
           it { is_expected.to contain_file('/etc/openvpn/test_server/scripts/add-tap-to-bridge.sh').with(ensure: 'present') }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^up\s+"/etc/openvpn/test_server/scripts/up\.sh"$}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^down\s+"/etc/openvpn/test_server/scripts/down\.sh"$}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-connect\s+"/etc/openvpn/test_server/scripts/connect\.sh"$}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-disconnect\s+"/etc/openvpn/test_server/scripts/disconnect\.sh"$}) }
+        end
+
+        context 'when not using scripts' do
+          let(:params) do
+            {
+              'country'           => 'CO',
+              'province'          => 'ST',
+              'city'              => 'Some City',
+              'organization'      => 'example.org',
+              'email'             => 'testemail@example.org'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^script-security\s+}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^up\s+}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^down\s+}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^client\-connect\s+}) }
+          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^client\-disconnect\s+}) }
         end
 
         case facts[:os]['family']

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -614,6 +614,25 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file('/etc/openvpn/test_server/keys/pre-shared.secret').with(ensure: 'absent') }
         end
 
+        context 'when pushing scripts' do
+          let(:params) do
+            {
+              'country'       => 'CO',
+              'province'      => 'ST',
+              'city'          => 'Some City',
+              'organization'  => 'example.org',
+              'email'         => 'testemail@example.org',
+              'scripts'       => {
+                'add-tap-to-bridge.sh' => {
+                  'ensure' => 'present'
+                }
+              }
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/openvpn/test_server/scripts/add-tap-to-bridge.sh').with(ensure: 'present') }
+        end
+
         case facts[:os]['family']
         when %r{FreeBSD}
           context 'when FreeBSD based machine' do
@@ -662,6 +681,10 @@ describe 'openvpn::server' do
               is_expected.to contain_file('/etc/openvpn/test_server/auth').
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
+            it {
+              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
+                with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
+            }
 
             # VPN server config file itself
 
@@ -696,6 +719,10 @@ describe 'openvpn::server' do
             }
             it {
               is_expected.to contain_file('/etc/openvpn/test_server/auth').
+                with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
+            }
+            it {
+              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
 
@@ -900,6 +927,10 @@ describe 'openvpn::server' do
             }
             it {
               is_expected.to contain_file('/etc/openvpn/test_server/auth').
+                with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
+            }
+            it {
+              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
             }
 

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -148,14 +148,20 @@ plugin <%= @pam_module_path %> "<%= @pam_module_arguments %>"
 <% if @management -%>
 management <%= @management_ip %> <%= @management_port %>
 <% end -%>
-<% if @up != '' or @down != ''-%>
+<% if @up or @down or @client_connect or @client_disconnect -%>
 script-security 2
 <% end -%>
-<% if @up != '' -%>
-up "<%= @up %>"
+<% if @up -%>
+up "<% unless @up =~ /^\// %><%= @_script_dir %>/<% end %><%= @up %>"
 <% end -%>
-<% if @down != '' -%>
-down "<%= @down %>"
+<% if @down -%>
+down "<% unless @down =~ /^\// %><%= @_script_dir %>/<% end %><%= @down %>"
+<% end -%>
+<% if @client_connect -%>
+client-connect "<% unless @client_connect =~ /^\// %><%= @_script_dir %>/<% end %><%= @client_connect %>"
+<% end -%>
+<% if @client_disconnect -%>
+client-disconnect "<% unless @client_disconnect =~ /^\// %><%= @_script_dir %>/<% end %><%= @client_disconnect %>"
 <% end -%>
 <% if @username_as_common_name -%>
 username-as-common-name


### PR DESCRIPTION
#### Pull Request (PR) description
This change allows packaging scripts with the `server` instance.

Example usage:

```
openvpn::server { 'test-site':
    ....
    up => '/etc/openvpn/test-site/scripts/add-tap-to-bridge.sh',
    scripts => {
        "add-tap-to-bridge.sh" => {content => 'a'},
    },
}
```

Anything that can go in a regular Puppet `file` resource can be used in the hash including `template`, `source`, and `content`.

`up`, `down`, `client-connect` and `client-disconnect` scripts will be checked for `/` and be considered to be in the `scripts` folder otherwise.

Tests pass locally.