### PR TITLE
Optionally manage logfile parent directory

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,6 +16,9 @@
 # @param duplicate_cn Allow multiple connections on one cn
 # @param local Interface for openvpn to bind to.
 # @param logfile Logfile for this openvpn server
+# @param manage_logfile_directory Manage the directory that the logfile is located in
+# @param logdirectory_user The owner user of the logfile directory
+# @param logdirectory_group The owner group of the logfile directory
 # @param port The port the openvpn server service is running on#
 # @param portshare The address and port to which non openvpn request shall be forwared, e.g. 127.0.0.1 8443
 # @param proto What IP protocol is being used.
@@ -135,6 +138,9 @@ define openvpn::server (
   Boolean $duplicate_cn                                             = false,
   String $local                                                     = $facts['ipaddress_eth0'],
   Variant[Boolean, String] $logfile                                 = false,
+  Boolean $manage_logfile_directory                                 = false,
+  String[1] $logdirectory_user                                      = 'nobody',
+  String[1] $logdirectory_group                                     = 'nobody',
   String $port                                                      = '1194',
   Optional[String] $portshare                                       = undef,
   Enum['tcp', 'tcp4', 'tcp6', 'udp', 'udp4', 'udp6'] $proto         = 'tcp',
@@ -239,6 +245,15 @@ define openvpn::server (
   }
   else {
     $lnotify = undef
+  }
+
+  if $manage_logfile_directory {
+    $logdir = dirname($logfile)
+    file { $logdir:
+      ensure => 'directory',
+      owner  => $logdirectory_user,
+      group  => $logdirectory_group,
+    }
   }
 
   # Selection block to enable or disable tls-server flag

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -302,7 +302,10 @@ describe 'openvpn::server' do
             'proto'           => 'udp',
             'group'           => 'someone',
             'user'            => 'someone',
-            'logfile'         => '/var/log/openvpn/test_server.log',
+            'logfile'         => '/var/log/openvpn/server1/test_server.log',
+            'manage_logfile_directory' => true,
+            'logdirectory_user' => 'someone',
+            'logdirectory_group' => 'someone',
             'status_log'      => '/tmp/test_server_status.log',
             'dev'             => 'tun1',
             'up'              => '/tmp/up',
@@ -352,7 +355,8 @@ describe 'openvpn::server' do
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^compress lz4$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+someone$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+someone$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^log\-append\s+/var/log/openvpn/test_server\.log$}) }
+        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^log\-append\s+/var/log/openvpn/server1/test_server\.log$}) }
+        it { is_expected.to contain_file('/var/log/openvpn/server1').with('ensure' => 'directory', 'owner' => 'someone', 'group' => 'someone') }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^status\s+/tmp/test_server_status\.log$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dev\s+tun1$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^local\s+2\.3\.4\.5$}) }


### PR DESCRIPTION
If the logfile path is set to a subdir (e.g.
/var/log/openvpn/$name/openvpn.log) someone needs to create that path.
This is a good a place as any to add that feature.

Signed-off-by: Florian Pritz <florian.pritz@rise-world.com>
