### PR TITLE
easy-rsa 3.0 by default for FreeBSD

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -2,7 +2,7 @@ openvpn::etc_directory: '/usr/local/etc'
 openvpn::group: 'nogroup'
 openvpn::link_openssl_cnf: true
 openvpn::pam_module_path: '/usr/local/lib/openvpn/openvpn-auth-pam.so'
-openvpn::additional_packages: ['easy-rsa2']
+openvpn::additional_packages: ['easy-rsa']
 openvpn::easyrsa_source: '/usr/local/share/easy-rsa'
-openvpn::default_easyrsa_ver: '2.0'
+openvpn::default_easyrsa_ver: '3.0'
 openvpn::namespecific_rclink: true

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,12 @@
       "operatingsystem": "Archlinux"
     },
     {
-      "operatingsystem": "FreeBSD"
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "12",
+        "13"
+      ]
+
     }
   ],
   "requirements": [


### PR DESCRIPTION
easy-rsa2 was removed from FreeBSD ports tree, see:
https://svnweb.freebsd.org/ports?view=revision&revision=r504939

switch to easy-rsa 3, tested on FreeBSD 12.0-RELEASE, FreeBSD 13-CURENT
