### PR TITLE
Fix file permission set to 644 on easy-rsa

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -64,6 +64,7 @@ define openvpn::ca (
 
   file { "${etc_directory}/openvpn/${name}/easy-rsa" :
     ensure             => directory,
+    mode               => '0755',
     recurse            => true,
     links              => 'follow',
     source_permissions => 'use',


### PR DESCRIPTION
#### Pull Request (PR) description



Os:
Red Hat Enterprise Linux Server release 7.6 (Maipo)
Puppet agent:  4.10.12
 

#### This Pull Request (PR) fixes the following issues

From (https://puppet.com/docs/puppet/5.5/types/file.html)
"If the mode is omitted (or explicitly set to undef), Puppet does not enforce permissions on existing files and creates new files with permissions of 0644."

```
Notice: /Stage[main]/Openvpn/Openvpn::Server[ovpn1]/Openvpn::Ca[ovpn1]/File[/etc/openvpn/ovpn1/easy-rsa/easyrsa]/mode: mode changed '0755' to '0644'
Notice: /Stage[main]/Openvpn/Openvpn::Server[ovpn1]/Openvpn::Ca[ovpn1]/Exec[initca ovpn1]/returns: /bin/sh: ./easyrsa: Permission denied
Error: './easyrsa --batch init-pki && ./easyrsa --batch build-ca nopass' returned 126 instead of one of [0]

```