### PR TITLE
Add RHEL 8 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,7 @@
   docker_sets:
     - set: ubuntu1804-64
     - set: ubuntu1604-64
+    - set: centos8-64
     - set: centos7-64
     - set: centos6-64
     - set: debian9-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,14 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64vpnserver.ma{hostname=vpnserver}-centos8-64vpnclienta.a{hostname=vpnclienta} BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos8-64vpnserver.ma{hostname=vpnserver}-centos8-64vpnclienta.a{hostname=vpnclienta} BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64vpnserver.ma{hostname=vpnserver}-centos7-64vpnclienta.a{hostname=vpnclienta} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -173,6 +173,18 @@ Hash of servers passed to openvpn::server defined type.
 
 Default value: {}
 
+##### `server_directory`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path of the server configuration. This is usually `/etc_directory/openvpn`, but RHEL/CentOS 8 uses `/etc_directory/openvpn/server`
+
+##### `server_service_name`
+
+Data type: `String[1]`
+
+Name of the openvpn server service. This is usually `openvpn`, but RHEL/CentOS 8 uses `openvpn-server`.
+
 ### openvpn::config
 
 This class sets up the openvpn enviornment as well as the default config file

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -9,5 +9,7 @@ openvpn::default_easyrsa_ver: '2.0'
 openvpn::easyrsa_source: '/usr/share/easy-rsa/'
 openvpn::additional_packages: ['easy-rsa']
 openvpn::ldap_auth_plugin_location: ~
+openvpn::server_service_name: 'openvpn'
+openvpn::server_directory: '/etc/openvpn'
 
 openvpn::deploy::prepare::etc_directory: "%{alias('openvpn::etc_directory')}"

--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -6,3 +6,4 @@ openvpn::additional_packages: ['easy-rsa2']
 openvpn::easyrsa_source: '/usr/local/share/easy-rsa'
 openvpn::default_easyrsa_ver: '2.0'
 openvpn::namespecific_rclink: true
+openvpn::server_directory: '/usr/local/etc/openvpn'

--- a/data/family/RedHat/8.yaml
+++ b/data/family/RedHat/8.yaml
@@ -1,0 +1,2 @@
+openvpn::server_directory: '/etc/openvpn/server'
+openvpn::server_service_name: 'openvpn-server'

--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -44,7 +44,7 @@ define openvpn::client_specific_config (
     -> Openvpn::Client_specific_config[$name]
   }
 
-  file { "${openvpn::etc_directory}/openvpn/${server}/client-configs/${name}":
+  file { "${openvpn::server_directory}/${server}/client-configs/${name}":
     ensure  => $ensure,
     content => template('openvpn/client_specific_config.erb'),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class openvpn (
   Stdlib::Unixpath                     $easyrsa_source,
   Variant[String[1], Array[String[1]]] $additional_packages,
   Optional[Stdlib::Absolutepath]       $ldap_auth_plugin_location,
+  String[1]                            $server_service_name,
+  Optional[Stdlib::Absolutepath]       $server_directory,
 
   Hash                                 $client_defaults                 = {},
   Hash                                 $clients                         = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@
 # @param revokes Hash of revokes passed to openvpn::revoke defined type.
 # @param server_defaults Hash of defaults for servers passed to openvpn::server defined type.
 # @param servers Hash of servers passed to openvpn::server defined type.
+# @param server_directory  Path of the server configuration. This is usually `/etc_directory/openvpn`, but RHEL/CentOS 8 uses `/etc_directory/openvpn/server`
+# @param server_service_name  Name of the openvpn server service. This is usually `openvpn`, but RHEL/CentOS 8 uses `openvpn-server`.
 #
 # @example
 #   class { 'openvpn':

--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -23,7 +23,7 @@ define openvpn::revoke (
   Openvpn::Client[$name]
   -> Openvpn::Revoke[$name]
 
-  $etc_directory = $openvpn::etc_directory
+  $server_directory = $openvpn::server_directory
 
   $revocation_command = $openvpn::easyrsa_version ? {
     '2.0' => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
@@ -31,22 +31,22 @@ define openvpn::revoke (
   }
 
   $renew_command = $openvpn::easyrsa_version ? {
-    '2.0'   => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${openvpn::etc_directory}/openvpn/${name}/crl.pem -config ${openvpn::etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
-    '3.0'   => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${etc_directory}/openvpn/${name}/crl.pem -config ${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+    '2.0'   => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${openvpn::server_directory}/${name}/crl.pem -config ${openvpn::server_directory}/${name}/easy-rsa/openssl.cnf",
+    '3.0'   => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${server_directory}/${name}/crl.pem -config ${server_directory}/${name}/easy-rsa/openssl.cnf",
     default => fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0."),
   }
 
   exec { "revoke certificate for ${name} in context of ${server}":
     command  => $revocation_command,
-    cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
-    creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
+    cwd      => "${server_directory}/${server}/easy-rsa",
+    creates  => "${server_directory}/${server}/easy-rsa/revoked/${name}",
     provider => 'shell',
     notify   => Exec["renew crl.pem on ${name}"],
   }
 
   exec { "renew crl.pem on ${name}":
     command  => $renew_command,
-    cwd      => "${openvpn::etc_directory}/openvpn/${name}/easy-rsa",
+    cwd      => "${openvpn::server_directory}/${name}/easy-rsa",
     provider => 'shell',
     schedule => "renew crl.pem schedule on ${name}",
   }

--- a/metadata.json
+++ b/metadata.json
@@ -27,14 +27,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/openvpn_init_spec.rb
+++ b/spec/classes/openvpn_init_spec.rb
@@ -19,7 +19,7 @@ describe 'openvpn', type: :class do
           it { is_expected.to create_class('openvpn') }
           it { is_expected.to contain_class('openvpn::service') }
         end
-      when 'Ubuntu-18.04', 'Ubuntu-16.04', 'CentOS-7', 'RedHat-7', 'Debian-8', 'Debian-9', %r{Archlinux}
+      when 'Ubuntu-18.04', 'Ubuntu-16.04', 'CentOS-7', 'RedHat-7', 'CentOS-8', 'RedHat-8', 'Debian-8', 'Debian-9', %r{Archlinux}
         let(:facts) do
           facts.merge(
             service_provider: 'systemd'

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -10,6 +10,12 @@ describe 'openvpn::ca', type: :define do
 
       case facts[:os]['family']
       when 'RedHat'
+        server_directory = if facts[:os]['release']['major'] == '8'
+                             '/etc/openvpn/server'
+                           else
+                             '/etc/openvpn'
+                           end
+
         context 'creating a server with the minimum parameters' do
           let(:params) do
             {
@@ -23,7 +29,7 @@ describe 'openvpn::ca', type: :define do
 
           it { is_expected.to contain_package('easy-rsa').with('ensure' => 'present') }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/crl.pem').with(
+            is_expected.to contain_file("#{server_directory}/test_server/crl.pem").with(
               'mode'    => '0640',
               'group'   => 'nobody'
             )
@@ -31,28 +37,28 @@ describe 'openvpn::ca', type: :define do
 
           # Files associated with a server config
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(mode: '0550') }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with(mode: '0550') }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem').
-              with(ensure: 'link', target: '/etc/openvpn/test_server/crl.pem')
+            is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/keys/crl.pem").
+              with(ensure: 'link', target: "#{server_directory}/test_server/crl.pem")
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/keys').
-              with(ensure: 'link', target: '/etc/openvpn/test_server/easy-rsa/keys')
+            is_expected.to contain_file("#{server_directory}/test_server/keys").
+              with(ensure: 'link', target: "#{server_directory}/test_server/easy-rsa/keys")
           }
 
           # Execs to working with certificates
 
-          it { is_expected.to contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh.pem') }
+          it { is_expected.to contain_exec('generate dh param test_server').with_creates("#{server_directory}/test_server/easy-rsa/keys/dh.pem") }
           it { is_expected.to contain_exec('initca test_server') }
           it { is_expected.to contain_exec('generate server cert test_server') }
           it { is_expected.to contain_exec('create crl.pem on test_server') }
           it { is_expected.not_to contain_exec('update crl.pem on test_server') }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_CA_EXPIRE=3650$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_CERT_EXPIRE=3650$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{EASYRSA_REQ_CN}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{EASYRSA_REQ_OU}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CA_EXPIRE=3650$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CERT_EXPIRE=3650$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{EASYRSA_REQ_CN}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{EASYRSA_REQ_OU}) }
         end
 
         context 'creating a ca setting all parameters' do
@@ -74,14 +80,16 @@ describe 'openvpn::ca', type: :define do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_CA_EXPIRE=365$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_CERT_EXPIRE=365$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_REQ_CN="yolo"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export EASYRSA_REQ_OU="NSA"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CA_EXPIRE=365$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CERT_EXPIRE=365$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_REQ_CN="yolo"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_REQ_OU="NSA"$}) }
 
-          it { is_expected.to contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh.pem') }
+          it { is_expected.to contain_exec('generate dh param test_server').with_creates("#{server_directory}/test_server/easy-rsa/keys/dh.pem") }
         end
       when 'Debian'
+        server_directory = '/etc/openvpn'
+
         context 'creating a server with the minimum parameters' do
           let(:params) do
             {
@@ -95,29 +103,29 @@ describe 'openvpn::ca', type: :define do
 
           # Files associated with a server config
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with(mode: '0550') }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with(mode: '0550') }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/keys/crl.pem').
-              with(ensure: 'link', target: '/etc/openvpn/test_server/crl.pem')
+            is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/keys/crl.pem").
+              with(ensure: 'link', target: "#{server_directory}/test_server/crl.pem")
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/keys').
-              with(ensure: 'link', target: '/etc/openvpn/test_server/easy-rsa/keys')
+            is_expected.to contain_file("#{server_directory}/test_server/keys").
+              with(ensure: 'link', target: "#{server_directory}/test_server/easy-rsa/keys")
           }
 
           # Execs to working with certificates
 
-          it { is_expected.to contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh2048.pem') }
+          it { is_expected.to contain_exec('generate dh param test_server').with_creates("#{server_directory}/test_server/easy-rsa/keys/dh2048.pem") }
           it { is_expected.to contain_exec('initca test_server') }
           it { is_expected.to contain_exec('generate server cert test_server') }
           it { is_expected.to contain_exec('create crl.pem on test_server') }
           it { is_expected.not_to contain_exec('update crl.pem on test_server') }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export CA_EXPIRE=3650$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export KEY_EXPIRE=3650$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{KEY_CN}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{KEY_NAME}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{KEY_OU}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export CA_EXPIRE=3650$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export KEY_EXPIRE=3650$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{KEY_CN}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{KEY_NAME}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{KEY_OU}) }
         end
 
         context 'creating a ca setting all parameters' do
@@ -139,13 +147,13 @@ describe 'openvpn::ca', type: :define do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export CA_EXPIRE=365$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export KEY_EXPIRE=365$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export KEY_CN="yolo"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export KEY_NAME="burp"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/vars').with_content(%r{^export KEY_OU="NSA"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export CA_EXPIRE=365$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export KEY_EXPIRE=365$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export KEY_CN="yolo"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export KEY_NAME="burp"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export KEY_OU="NSA"$}) }
 
-          it { is_expected.to contain_exec('generate dh param test_server').with_creates('/etc/openvpn/test_server/easy-rsa/keys/dh2048.pem') }
+          it { is_expected.to contain_exec('generate dh param test_server').with_creates("#{server_directory}/test_server/easy-rsa/keys/dh2048.pem") }
         end
 
         context 'when Debian based machine' do
@@ -160,16 +168,16 @@ describe 'openvpn::ca', type: :define do
           end
 
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/easy-rsa/openssl.cnf').with(
+            is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/openssl.cnf").with(
               'ensure'  => 'link',
-              'target'  => '/etc/openvpn/test_server/easy-rsa/openssl-1.0.0.cnf',
+              'target'  => "#{server_directory}/test_server/easy-rsa/openssl-1.0.0.cnf",
               'recurse' => nil,
               'group'   => 'nogroup'
             )
           }
 
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/crl.pem').with(
+            is_expected.to contain_file("#{server_directory}/test_server/crl.pem").with(
               'mode'    => '0640',
               'group'   => 'nogroup'
             )

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -18,12 +18,23 @@ describe 'openvpn::client', type: :define do
       let(:title) { 'test_client' }
       let(:params) { { server: 'test_server' } }
 
+      server_directory = case facts[:os]['family']
+                         when 'CentOS', 'RedHat'
+                           if facts[:os]['release']['major'] == '8'
+                             '/etc/openvpn/server'
+                           else
+                             '/etc/openvpn'
+                           end
+                         else
+                           '/etc/openvpn'
+                         end
+
       it { is_expected.to compile.with_all_deps }
 
       it { is_expected.to contain_exec('generate certificate for test_client in context of test_server') }
 
       ['test_client', 'test_client/keys/test_client'].each do |directory|
-        it { is_expected.to contain_file("/etc/openvpn/test_server/download-configs/#{directory}") }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/#{directory}") }
       end
 
       case facts[:os]['family']
@@ -31,9 +42,9 @@ describe 'openvpn::client', type: :define do
         context 'system with easyrsa2' do
           ['test_client.crt', 'test_client.key', 'ca.crt'].each do |file|
             it {
-              is_expected.to contain_file("/etc/openvpn/test_server/download-configs/test_client/keys/test_client/#{file}").with(
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/#{file}").with(
                 'ensure'  => 'link',
-                'target'  => "/etc/openvpn/test_server/easy-rsa/keys/#{file}"
+                'target'  => "#{server_directory}/test_server/easy-rsa/keys/#{file}"
               )
             }
           end
@@ -41,21 +52,21 @@ describe 'openvpn::client', type: :define do
       when 'CentOS', 'RedHat', %r{Archlinux}, %r{FreeBSD}
         context 'system with easyrsa3' do
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/test_client.crt').with(
+            is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/test_client.crt").with(
               'ensure'  => 'link',
-              'target'  => '/etc/openvpn/test_server/easy-rsa/keys/issued/test_client.crt'
+              'target'  => "#{server_directory}/test_server/easy-rsa/keys/issued/test_client.crt"
             )
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/test_client.key').with(
+            is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/test_client.key").with(
               'ensure'  => 'link',
-              'target'  => '/etc/openvpn/test_server/easy-rsa/keys/private/test_client.key'
+              'target'  => "#{server_directory}/test_server/easy-rsa/keys/private/test_client.key"
             )
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/ca.crt').with(
+            is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/ca.crt").with(
               'ensure'  => 'link',
-              'target'  => '/etc/openvpn/test_server/easy-rsa/keys/ca.crt'
+              'target'  => "#{server_directory}/test_server/easy-rsa/keys/ca.crt"
             )
           }
         end
@@ -63,7 +74,7 @@ describe 'openvpn::client', type: :define do
 
       it {
         is_expected.to contain_exec('tar the thing test_server with test_client').with(
-          'cwd'     => '/etc/openvpn/test_server/download-configs/',
+          'cwd'     => "#{server_directory}/test_server/download-configs/",
           'command' => '/bin/rm test_client.tar.gz; tar --exclude=\*.conf.d -chzvf test_client.tar.gz test_client test_client.tblk'
         )
       }
@@ -76,28 +87,28 @@ describe 'openvpn::client', type: :define do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^ca\s+keys/test_client/ca\.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^cert\s+keys/test_client/test_client.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^key\s+keys/test_client/test_client\.key$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^dev\s+tun$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^proto\s+tcp$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote\s+foo.example.com\s+1194$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^comp-lzo$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^resolv-retry\s+infinite$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^nobind$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^persist-key$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^persist-tun$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^mute-replay-warnings$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^ns\-cert\-type\s+server$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^verb\s+3$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^mute\s+20$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^auth-retry\s+none$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^tls-client$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^verify-x509-name}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^sndbuf}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^rcvbuf}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^pull}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^ca\s+keys/test_client/ca\.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cert\s+keys/test_client/test_client.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^key\s+keys/test_client/test_client\.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^dev\s+tun$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^proto\s+tcp$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote\s+foo.example.com\s+1194$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^comp-lzo$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^resolv-retry\s+infinite$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^nobind$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^persist-key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^persist-tun$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^mute-replay-warnings$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^ns\-cert\-type\s+server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verb\s+3$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^mute\s+20$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^auth-retry\s+none$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-client$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verify-x509-name}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^sndbuf}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^rcvbuf}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^pull}) }
       end
 
       context 'setting all of the parameters' do
@@ -132,42 +143,42 @@ describe 'openvpn::client', type: :define do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^ca\s+keys\/test_client\/ca\.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^cert\s+keys\/test_client\/test_client.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^key\s+keys\/test_client\/test_client\.key$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^dev\s+tap$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^proto\s+udp$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote\s+somewhere\s+123$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote\s+galaxy\s+123$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^compress lz4$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^resolv-retry\s+2m$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^verb\s+1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^mute\s+10$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^auth-retry\s+interact$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^setenv\s+CLIENT_CERT\s+0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^setenv_safe\s+FORWARD_COMPATIBLE\s+1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^cipher\s+AES-256-CBC$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^tls-client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^verify-x509-name\s+"test_server"\s+name$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^sndbuf\s+393216$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^rcvbuf\s+393215$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/README').with_content(%r{^readme text$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^pull$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^remote-cert-tls\s+server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^ca\s+keys\/test_client\/ca\.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cert\s+keys\/test_client\/test_client.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^key\s+keys\/test_client\/test_client\.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^dev\s+tap$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^proto\s+udp$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote\s+somewhere\s+123$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote\s+galaxy\s+123$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^compress lz4$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^resolv-retry\s+2m$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verb\s+1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^mute\s+10$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^auth-retry\s+interact$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^setenv\s+CLIENT_CERT\s+0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^setenv_safe\s+FORWARD_COMPATIBLE\s+1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher\s+AES-256-CBC$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verify-x509-name\s+"test_server"\s+name$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^sndbuf\s+393216$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^rcvbuf\s+393215$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/README").with_content(%r{^readme text$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^pull$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote-cert-tls\s+server$}) }
       end
 
       context 'test tls_crypt' do
         let(:params) { { 'server' => 'test_server', 'tls_crypt' => true } }
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^tls-crypt keys/test_client/ta\.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-crypt keys/test_client/ta\.key$}) }
       end
 
       context 'omitting the cipher key' do
         let(:params) { { 'server' => 'test_server' } }
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^cipher AES-256-CBC$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher AES-256-CBC$}) }
       end
 
       context 'should fail if specifying an openvpn::server with extca_enabled=true' do
@@ -219,19 +230,19 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_exec('generate certificate for test_client in context of my_already_existing_ca') }
 
         # Check that certificate files point to the provided CA
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^ca\s+keys/test_client/ca\.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^cert\s+keys/test_client/test_client.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^key\s+keys/test_client/test_client\.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^ca\s+keys/test_client/ca\.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cert\s+keys/test_client/test_client.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^key\s+keys/test_client/test_client\.key$}) }
 
         case facts[:os]['family']
         when 'Ubuntu', 'Debian'
           context 'system with easyrsa2' do
             ['test_client.crt', 'test_client.key', 'ca.crt'].each do |file|
               it {
-                is_expected.to contain_file("/etc/openvpn/test_server/download-configs/test_client/keys/test_client/#{file}").with(
+                is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/#{file}").with(
                   'ensure'  => 'link',
-                  'target'  => "/etc/openvpn/my_already_existing_ca/easy-rsa/keys/#{file}"
+                  'target'  => "#{server_directory}/my_already_existing_ca/easy-rsa/keys/#{file}"
                 )
               }
             end
@@ -239,21 +250,21 @@ describe 'openvpn::client', type: :define do
         when 'CentOS', 'RedHat', %r{Archlinux}, %r{FreeBSD}
           context 'system with easyrsa3' do
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/test_client.crt').with(
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/test_client.crt").with(
                 'ensure'  => 'link',
-                'target'  => '/etc/openvpn/my_already_existing_ca/easy-rsa/keys/issued/test_client.crt'
+                'target'  => "#{server_directory}/my_already_existing_ca/easy-rsa/keys/issued/test_client.crt"
               )
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/test_client.key').with(
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/test_client.key").with(
                 'ensure'  => 'link',
-                'target'  => '/etc/openvpn/my_already_existing_ca/easy-rsa/keys/private/test_client.key'
+                'target'  => "#{server_directory}/my_already_existing_ca/easy-rsa/keys/private/test_client.key"
               )
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/keys/test_client/ca.crt').with(
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/keys/test_client/ca.crt").with(
                 'ensure'  => 'link',
-                'target'  => '/etc/openvpn/my_already_existing_ca/easy-rsa/keys/ca.crt'
+                'target'  => "#{server_directory}/my_already_existing_ca/easy-rsa/keys/ca.crt"
               )
             }
           end
@@ -279,7 +290,7 @@ describe 'openvpn::client', type: :define do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^this that$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^this that$}) }
       end
     end
   end

--- a/spec/defines/openvpn_client_specific_config_spec.rb
+++ b/spec/defines/openvpn_client_specific_config_spec.rb
@@ -27,12 +27,23 @@ describe 'openvpn::client_specific_config', type: :define do
         }
       end
 
+      server_directory = case facts[:os]['family']
+                         when 'CentOS', 'RedHat'
+                           if facts[:os]['release']['major'] == '8'
+                             '/etc/openvpn/server'
+                           else
+                             '/etc/openvpn'
+                           end
+                         else
+                           '/etc/openvpn'
+                         end
+
       it { is_expected.to compile.with_all_deps }
 
-      it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client') }
+      it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client") }
 
       describe 'setting no paramter at all' do
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{\A\n\z}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{\A\n\z}) }
       end
 
       describe 'setting all parameters' do
@@ -49,13 +60,13 @@ describe 'openvpn::client_specific_config', type: :define do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^iroute 10.0.1.0 255.255.255.0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^iroute-ipv6 2001:db8:1234::/64$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^ifconfig-push 10.10.10.2 255.255.255.0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^ifconfig-ipv6-push 2001:db8:0:123::2/64 2001:db8:0:123::1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^push "dhcp-option DNS 8.8.8.8"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^push "redirect-gateway def1"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server/client-configs/test_client').with_content(%r{^push "route 10.200.100.0 255.255.255.0 10.10.10.1"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^iroute 10.0.1.0 255.255.255.0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^iroute-ipv6 2001:db8:1234::/64$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^ifconfig-push 10.10.10.2 255.255.255.0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^ifconfig-ipv6-push 2001:db8:0:123::2/64 2001:db8:0:123::1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "dhcp-option DNS 8.8.8.8"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "redirect-gateway def1"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "route 10.200.100.0 255.255.255.0 10.10.10.1"$}) }
       end
     end
   end

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -8,17 +8,31 @@ describe 'openvpn::server' do
       end
       let(:title) { 'test_server' }
 
+      server_directory = case facts[:os]['family']
+                         when 'CentOS', 'RedHat'
+                           if facts[:os]['release']['major'] == '8'
+                             '/etc/openvpn/server'
+                           else
+                             '/etc/openvpn'
+                           end
+                         when %r{FreeBSD}
+                           '/usr/local/etc/openvpn'
+                         else
+                           '/etc/openvpn'
+                         end
+      server_directory_regex = server_directory.gsub('/', '\/')
+
       # common tests for any easyrsa version
       context 'creating a server without any parameter' do
         let(:params) { {} }
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'creating a server partial parameters: country' do
         let(:params) { { 'country' => 'CO' } }
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'creating a server partial parameters: country, province' do
@@ -29,7 +43,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'creating a server partial parameters: country, province, city' do
@@ -41,7 +55,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'creating a server partial parameters: country, province, city, organization' do
@@ -54,7 +68,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'when using not existed shared ca' do
@@ -64,7 +78,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'should fail if setting extca_enabled=true without specifying any other extca_* options' do
@@ -74,7 +88,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'should fail if setting extca_enabled=true and tls_auth=true without providing extca_tls_auth_key_file' do
@@ -90,7 +104,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'when altering send and receive buffers' do
@@ -106,8 +120,8 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^sndbuf\s+393216$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^rcvbuf\s+393215$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^sndbuf\s+393216$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^rcvbuf\s+393215$}) }
       end
 
       context 'when using udp4' do
@@ -122,7 +136,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp4$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+udp4$}) }
       end
 
       context 'when using udp6' do
@@ -137,7 +151,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp6$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+udp6$}) }
       end
 
       context 'when using tcp4' do
@@ -152,7 +166,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tcp4-server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+tcp4-server$}) }
       end
 
       context 'when using tcp6' do
@@ -167,7 +181,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tcp6-server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+tcp6-server$}) }
       end
 
       context 'when using invalid value for proto' do
@@ -182,7 +196,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { expect { is_expected.to contain_file('/etc/openvpn/test_server') }.to raise_error(Puppet::PreformattedError) }
+        it { expect { is_expected.to contain_file("#{server_directory}/test_server") }.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'creating a server in client mode' do
@@ -202,34 +216,34 @@ describe 'openvpn::server' do
         context 'nobind is true' do
           let(:nobind) { true }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^nobind$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{port\s+\d+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^nobind$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{port\s+\d+}) }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client$}) }
         it {
-          is_expected.to contain_file('/etc/openvpn/test_client.conf').
+          is_expected.to contain_file("#{server_directory}/test_client.conf").
             with_content(%r{^remote\s+vpn.example.com\s+12345$})
         }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^server-poll-timeout\s+1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^ping-timer-rem$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^ns-cert-type server}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^mode\s+server$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^client-config-dir}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^dh}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^tls-client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^key-direction 1$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{nobind}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^port\s+\d+$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').without_content(%r{^remote-random-hostname$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').without_content(%r{^remote-random$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^server-poll-timeout\s+1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ping-timer-rem$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ns-cert-type server}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^mode\s+server$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client-config-dir}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^dh}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^tls-client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^key-direction 1$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{nobind}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^port\s+\d+$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").without_content(%r{^remote-random-hostname$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").without_content(%r{^remote-random$}) }
 
         it { is_expected.not_to contain_openvpn__ca('test_client') }
 
         case facts[:os]['family']
         when 'RedHat'
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client/keys').
+            is_expected.to contain_file("#{server_directory}/test_client/keys").
               with(ensure: 'directory', mode: '0750', group: 'nobody')
           }
         end
@@ -251,34 +265,34 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client$}) }
         it {
-          is_expected.to contain_file('/etc/openvpn/test_client.conf').
+          is_expected.to contain_file("#{server_directory}/test_client.conf").
             with_content(%r{^remote\s+vpn1.example.com\s+12345$})
         }
         it {
-          is_expected.to contain_file('/etc/openvpn/test_client.conf').
+          is_expected.to contain_file("#{server_directory}/test_client.conf").
             with_content(%r{^remote\s+vpn2.example.com\s+23456$})
         }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^remote-random-hostname$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^remote-random$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^server-poll-timeout\s+1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^ping-timer-rem$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^ns-cert-type server}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^mode\s+server$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^client-config-dir}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^dh}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^tls-client$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^key-direction 1$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_client.conf').with_content(%r{nobind}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_client.conf').with_content(%r{^port\s+\d+$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^remote-random-hostname$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^remote-random$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^server-poll-timeout\s+1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ping-timer-rem$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ns-cert-type server}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^mode\s+server$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client-config-dir}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^dh}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^tls-client$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^key-direction 1$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{nobind}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^port\s+\d+$}) }
 
         it { is_expected.not_to contain_openvpn__ca('test_client') }
 
         case facts[:os]['family']
         when 'RedHat'
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client/keys').
+            is_expected.to contain_file("#{server_directory}/test_client/keys").
               with(ensure: 'directory', mode: '0750', group: 'nobody')
           }
         end
@@ -305,11 +319,11 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSEnable\s+yes$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSCACertFile\s+/etc/ldap/ca.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSCACertDir\s+/etc/ldap/certs$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').without_content(%r{^\s+TLSCertFile.*$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').without_content(%r{^\s+TLSKeyFile.*$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSEnable\s+yes$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSCACertFile\s+/etc/ldap/ca.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSCACertDir\s+/etc/ldap/certs$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").without_content(%r{^\s+TLSCertFile.*$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").without_content(%r{^\s+TLSKeyFile.*$}) }
           end
 
           context 'creating a server with ldap authentication enabled and using ldap client certificates' do
@@ -331,11 +345,11 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSEnable\s+yes$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSCACertFile\s+/etc/ldap/ca.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSCACertDir\s+/etc/ldap/certs$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSCertFile\s+/etc/ldap/client-cert.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server/auth/ldap.conf').with_content(%r{^\s+TLSKeyFile\s+/etc/ldap/client-key.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSEnable\s+yes$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSCACertFile\s+/etc/ldap/ca.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSCACertDir\s+/etc/ldap/certs$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSCertFile\s+/etc/ldap/client-cert.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server/auth/ldap.conf").with_content(%r{^\s+TLSKeyFile\s+/etc/ldap/client-key.pem$}) }
           end
         end
       end
@@ -399,59 +413,59 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^mode\s+server$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client-config-dir\s+/etc/openvpn/test_server/client-configs$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+/etc/openvpn/test_server/keys/ca.crt$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+udp$}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tls-server$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^port\s+123$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^compress lz4$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+someone$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+someone$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^log\-append\s+/var/log/openvpn/server1/test_server\.log$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^mode\s+server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client-config-dir\s+#{server_directory}/test_server/client-configs$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory}/test_server/keys/ca.crt$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+udp$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+tls-server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port\s+123$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^compress lz4$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+someone$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^user\s+someone$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^log\-append\s+/var/log/openvpn/server1/test_server\.log$}) }
         it { is_expected.to contain_file('/var/log/openvpn/server1').with('ensure' => 'directory', 'owner' => 'someone', 'group' => 'someone') }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^status\s+/tmp/test_server_status\.log$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dev\s+tun1$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^local\s+2\.3\.4\.5$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^server\s+2\.3\.4\.0\s+255\.255\.0\.0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^server-ipv6\s+fe80:1337:1337:1337::/64$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^push\s+"dhcp-option\s+DNS\s+172\.31\.0\.30"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^push\s+"route\s+172\.31\.0\.0\s+255\.255\.0\.0"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^route\s+192.168.30.0\s+255.255.255.0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^route\s+192.168.35.0\s+255.255.0.0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^route-ipv6\s+2001:db8:1234::/64$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^route-ipv6\s+2001:db8:abcd::/64$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^keepalive\s+10\s+120$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^topology\s+subnet$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^management\s+1.3.3.7 1337$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^verb mute$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cipher DES-CBC$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^persist-key$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^persist-tun$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^status\s+/tmp/test_server_status\.log$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dev\s+tun1$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^local\s+2\.3\.4\.5$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^server\s+2\.3\.4\.0\s+255\.255\.0\.0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^server-ipv6\s+fe80:1337:1337:1337::/64$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^push\s+"dhcp-option\s+DNS\s+172\.31\.0\.30"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^push\s+"route\s+172\.31\.0\.0\s+255\.255\.0\.0"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^route\s+192.168.30.0\s+255.255.255.0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^route\s+192.168.35.0\s+255.255.0.0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^route-ipv6\s+2001:db8:1234::/64$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^route-ipv6\s+2001:db8:abcd::/64$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^keepalive\s+10\s+120$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^topology\s+subnet$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^management\s+1.3.3.7 1337$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^verb mute$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cipher DES-CBC$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^persist-key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^persist-tun$}) }
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^up "/tmp/up"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^down "/tmp/down"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client-connect "/tmp/connect"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client-disconnect "/tmp/disconnect"$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^script-security 2$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+/etc/openvpn/test_server/keys/ta.key$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key-direction 0$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^this that$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^up "/tmp/up"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^down "/tmp/down"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client-connect "/tmp/connect"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client-disconnect "/tmp/disconnect"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^script-security 2$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^duplicate-cn$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth\s+#{server_directory}/test_server/keys/ta.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key-direction 0$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^this that$}) }
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^fragment 1412$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^port-share 127.0.0.1 8443$}) }
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^secret /etc/openvpn/test_server/keys/pre-shared.secret$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^fragment 1412$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port-share 127.0.0.1 8443$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^secret #{server_directory}/test_server/keys/pre-shared.secret$}) }
 
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^server-poll-timeout}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ping-timer-rem}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^sndbuf}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^rcvbuf}) }
-        it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^remote-cert-tls server$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^server-poll-timeout}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ping-timer-rem}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^sndbuf}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^rcvbuf}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^remote-cert-tls server$}) }
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server/keys/pre-shared.secret').with_content(%r{^secretsecret1234$}).with(ensure: 'present') }
+        it { is_expected.to contain_file("#{server_directory}/test_server/keys/pre-shared.secret").with_content(%r{^secretsecret1234$}).with(ensure: 'present') }
         it { is_expected.to contain_schedule('renew crl.pem schedule on test_server') }
         it { is_expected.to contain_exec('renew crl.pem on test_server') }
 
@@ -488,7 +502,7 @@ describe 'openvpn::server' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-crypt\s+/etc/openvpn/test_server/keys/ta.key$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-crypt\s+#{server_directory}/test_server/keys/ta.key$}) }
 
         # OpenVPN easy-rsa CA
         it { is_expected.to contain_openvpn__ca('test_server').with(tls_static_key: true) }
@@ -556,9 +570,9 @@ describe 'openvpn::server' do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+/etc/openvpn/test_server/keys/mylittlepony.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+/etc/openvpn/test_server/keys/mylittlepony.key$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+/etc/openvpn/test_server/keys/dh2048.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys/mylittlepony.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys/mylittlepony.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh2048.pem$}) }
         end
 
         context 'creating a server in client mode' do
@@ -576,16 +590,16 @@ describe 'openvpn::server' do
           end
 
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^ca /etc/openvpn/test_client/keys/ca.crt$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^ca #{server_directory}/test_client/keys/ca.crt$})
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^cert /etc/openvpn/test_client/keys/test_client.crt$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^cert #{server_directory}/test_client/keys/test_client.crt$})
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^key /etc/openvpn/test_client/keys/test_client.key$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^key #{server_directory}/test_client/keys/test_client.key$})
           }
         end
 
@@ -611,13 +625,13 @@ describe 'openvpn::server' do
 
           # Check that certificate files point to the provide CA
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^mode\s+server$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-config\-dir\s+\/etc\/openvpn\/test_server\/client\-configs$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^mode\s+server$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-config\-dir\s+#{server_directory_regex}\/test_server\/client\-configs$}) }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/ca.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/custom_common_name.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/custom_common_name.key$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/dh2048.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/ca.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/custom_common_name.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/custom_common_name.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/dh2048.pem$}) }
         end
         context 'creating a server with the minimum parameters' do
           let(:params) do
@@ -635,37 +649,37 @@ describe 'openvpn::server' do
 
           # VPN server config file itself
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^mode\s+server$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-config\-dir\s+\/etc\/openvpn\/test_server\/client\-configs$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+\/etc\/openvpn\/test_server\/keys\/ca.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+\/etc\/openvpn\/test_server\/keys\/server.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+\/etc\/openvpn\/test_server\/keys\/server.key$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+\/etc\/openvpn\/test_server\/keys\/dh2048.pem$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^proto\s+tcp-server$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-server$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^port\s+1194$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^comp-lzo$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^log\-append\s+test_server\/openvpn\.log$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^status\s+/var/log/openvpn/test_server-status\.log$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dev\s+tun0$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^local\s+10\.0\.2\.15$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ifconfig-pool-persist}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify\s+\/etc\/openvpn\/test_server\/crl.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^mode\s+server$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-config\-dir\s+#{server_directory_regex}\/test_server\/client\-configs$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory_regex}\/test_server\/keys\/ca.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory_regex}\/test_server\/keys\/server.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory_regex}\/test_server\/keys\/server.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory_regex}\/test_server\/keys\/dh2048.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+tcp-server$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-server$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port\s+1194$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^comp-lzo$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^log\-append\s+test_server\/openvpn\.log$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^status\s+/var/log/openvpn/test_server-status\.log$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dev\s+tun0$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^local\s+10\.0\.2\.15$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ifconfig-pool-persist}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify\s+#{server_directory_regex}\/test_server\/crl.pem$}) }
           it { is_expected.not_to contain_schedule('renew crl.pem schedule on test_server') }
           it { is_expected.not_to contain_exec('renew crl.pem on test_server') }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^secret}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^secret}) }
 
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{verb}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{cipher AES-256-CBC}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{persist-key}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{persist-tun}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^duplicate-cn$}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ns-cert-type server}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^fragment}) }
-          it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^port-share}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{verb}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{cipher AES-256-CBC}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-key}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-tun}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^duplicate-cn$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ns-cert-type server}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^fragment}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port-share}) }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/keys/pre-shared.secret').with(ensure: 'absent') }
+          it { is_expected.to contain_file("#{server_directory}/test_server/keys/pre-shared.secret").with(ensure: 'absent') }
         end
 
         context 'when pushing scripts' do
@@ -688,11 +702,11 @@ describe 'openvpn::server' do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server/scripts/add-tap-to-bridge.sh').with(ensure: 'present') }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^up\s+"/etc/openvpn/test_server/scripts/up\.sh"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^down\s+"/etc/openvpn/test_server/scripts/down\.sh"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-connect\s+"/etc/openvpn/test_server/scripts/connect\.sh"$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-disconnect\s+"/etc/openvpn/test_server/scripts/disconnect\.sh"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server/scripts/add-tap-to-bridge.sh").with(ensure: 'present') }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^up\s+"#{server_directory}/test_server/scripts/up\.sh"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^down\s+"#{server_directory}/test_server/scripts/down\.sh"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-connect\s+"#{server_directory}/test_server/scripts/connect\.sh"$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-disconnect\s+"#{server_directory}/test_server/scripts/disconnect\.sh"$}) }
         end
 
         context 'when not using scripts' do
@@ -706,11 +720,11 @@ describe 'openvpn::server' do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^script-security\s+}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^up\s+}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^down\s+}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^client\-connect\s+}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').without_content(%r{^client\-disconnect\s+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").without_content(%r{^script-security\s+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").without_content(%r{^up\s+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").without_content(%r{^down\s+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").without_content(%r{^client\-connect\s+}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").without_content(%r{^client\-disconnect\s+}) }
         end
 
         case facts[:os]['family']
@@ -729,9 +743,9 @@ describe 'openvpn::server' do
 
             it { is_expected.to contain_file('/etc/rc.conf.d/openvpn_test_server') }
             it { is_expected.to contain_service('openvpn_test_server') }
-            it { is_expected.to contain_file('/usr/local/etc/openvpn/test_server') }
+            it { is_expected.to contain_file("#{server_directory}/test_server") }
             it { is_expected.to contain_file('/usr/local/etc/rc.d/openvpn_test_server') }
-            it { is_expected.to contain_file('/usr/local/etc/openvpn/test_server.conf').with_content(%r{/usr/local/etc}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{/usr/local/etc}) }
           end
           context 'creating a server with the minimum parameters' do
             let(:params) do
@@ -746,30 +760,30 @@ describe 'openvpn::server' do
 
             # Files associated with a server config
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server').
+              is_expected.to contain_file("#{server_directory}/test_server").
                 with(ensure: 'directory', mode: '0750', group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/client-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/client-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/auth').
+              is_expected.to contain_file("#{server_directory}/test_server/auth").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
+              is_expected.to contain_file("#{server_directory}/test_server/scripts").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
 
             # VPN server config file itself
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nogroup$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+nobody$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+nogroup$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^user\s+nobody$}) }
           end
 
         when 'Debian'
@@ -786,30 +800,30 @@ describe 'openvpn::server' do
 
             # Files associated with a server config
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server').
+              is_expected.to contain_file("#{server_directory}/test_server").
                 with(ensure: 'directory', mode: '0750', group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/client-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/client-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/auth').
+              is_expected.to contain_file("#{server_directory}/test_server/auth").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
+              is_expected.to contain_file("#{server_directory}/test_server/scripts").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nogroup')
             }
 
             # VPN server config file itself
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nogroup$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+nobody$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+nogroup$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^user\s+nobody$}) }
           end
 
           context 'when Debian based machine' do
@@ -824,8 +838,8 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nogroup$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib/openvpn/openvpn-plugin-auth-pam.so "login"$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+nogroup$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^plugin /usr/lib/openvpn/openvpn-plugin-auth-pam.so "login"$}) }
 
             context 'enabled autostart_all' do
               let(:pre_condition) { 'class { "openvpn": autostart_all => true }' }
@@ -914,9 +928,9 @@ describe 'openvpn::server' do
             }
           end
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+/etc/openvpn/test_server/keys/issued/mylittlepony.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+/etc/openvpn/test_server/keys/private/mylittlepony.key$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+/etc/openvpn/test_server/keys/dh.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys/issued/mylittlepony.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys/private/mylittlepony.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh.pem$}) }
         end
 
         context 'creating a server in client mode' do
@@ -934,16 +948,16 @@ describe 'openvpn::server' do
           end
 
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^ca /etc/openvpn/test_client/keys/ca.crt$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^ca #{server_directory}/test_client/keys/ca.crt$})
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^cert /etc/openvpn/test_client/keys/issued/test_client.crt$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^cert #{server_directory}/test_client/keys/issued/test_client.crt$})
           }
           it {
-            is_expected.to contain_file('/etc/openvpn/test_client.conf').
-              with_content(%r{^key /etc/openvpn/test_client/keys/private/test_client.key$})
+            is_expected.to contain_file("#{server_directory}/test_client.conf").
+              with_content(%r{^key #{server_directory}/test_client/keys/private/test_client.key$})
           }
         end
 
@@ -969,13 +983,13 @@ describe 'openvpn::server' do
 
           # Check that certificate files point to the provide CA
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^mode\s+server$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^client\-config\-dir\s+\/etc\/openvpn\/test_server\/client\-configs$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^mode\s+server$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-config\-dir\s+#{server_directory_regex}\/test_server\/client\-configs$}) }
 
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/ca.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/issued/custom_common_name.crt$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/private\/custom_common_name.key$}) }
-          it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+\/etc\/openvpn\/my_already_existing_ca\/keys\/dh.pem$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/ca.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/issued/custom_common_name.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/private\/custom_common_name.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory_regex}\/my_already_existing_ca\/keys\/dh.pem$}) }
         end
 
         case facts[:os]['family']
@@ -993,30 +1007,30 @@ describe 'openvpn::server' do
 
             # Files associated with a server config
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server').
+              is_expected.to contain_file("#{server_directory}/test_server").
                 with(ensure: 'directory', mode: '0750', group: 'nobody')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/client-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/client-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/download-configs').
+              is_expected.to contain_file("#{server_directory}/test_server/download-configs").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/auth').
+              is_expected.to contain_file("#{server_directory}/test_server/auth").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
             }
             it {
-              is_expected.to contain_file('/etc/openvpn/test_server/scripts').
+              is_expected.to contain_file("#{server_directory}/test_server/scripts").
                 with(ensure: 'directory', mode: '0750', recurse: true, group: 'nobody')
             }
 
             # VPN server config file itself
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^user\s+nobody$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+nobody$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^user\s+nobody$}) }
           end
 
           context 'RedHat using an external CA and enabling tls-auth' do
@@ -1033,19 +1047,19 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+\/etc\/openvpn\/test_server\/keys\/ca.crt$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify\s+\/etc\/openvpn\/test_server\/crl.pem$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+\/etc\/openvpn\/test_server\/keys\/server.crt$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+\/etc\/openvpn\/test_server\/keys\/server.key$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+\/etc\/openvpn\/test_server\/keys\/dh2048.pem$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+\/etc\/openvpn\/test_server\/keys\/ta.key$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory_regex}\/test_server\/keys\/ca.crt$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify\s+#{server_directory_regex}\/test_server\/crl.pem$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory_regex}\/test_server\/keys\/server.crt$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory_regex}\/test_server\/keys\/server.key$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory_regex}\/test_server\/keys\/dh2048.pem$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth\s+#{server_directory_regex}\/test_server\/keys\/ta.key$}) }
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+/etc/ipa/ca.crt$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify\s+/etc/ipa/ca_crl.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+/etc/pki/tls/certs/localhost.crt$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+/etc/pki/tls/private/localhost.key$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+/etc/ipa/dh.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth\s+/etc/openvpn/keys/ta.key$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+/etc/ipa/ca.crt$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify\s+/etc/ipa/ca_crl.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+/etc/pki/tls/certs/localhost.crt$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+/etc/pki/tls/private/localhost.key$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+/etc/ipa/dh.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth\s+/etc/openvpn/keys/ta.key$}) }
           end
 
           context 'RedHat using an external CA and without tls-auth' do
@@ -1061,18 +1075,18 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+/etc/openvpn/test_server/keys}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify\s+/etc/openvpn/test_server}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+/etc/openvpn/test_server/keys}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+/etc/openvpn/test_server/keys}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+/etc/openvpn/test_server/keys}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^tls-auth}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+#{server_directory}/test_server/keys}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify\s+#{server_directory}/test_server}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth}) }
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^ca\s+/etc/ipa/ca.crt$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify\s+/etc/ipa/ca_crl.pem$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^cert\s+/etc/pki/tls/certs/localhost.crt$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^key\s+/etc/pki/tls/private/localhost.key$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^dh\s+/etc/ipa/dh.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ca\s+/etc/ipa/ca.crt$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify\s+/etc/ipa/ca_crl.pem$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+/etc/pki/tls/certs/localhost.crt$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+/etc/pki/tls/private/localhost.key$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+/etc/ipa/dh.pem$}) }
           end
 
           context 'when RedHat based machine with different pam_module_arguments and crl_verify disabled' do
@@ -1089,8 +1103,8 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "openvpn login USERNAME password PASSWORD"$}) }
-            it { is_expected.not_to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^crl-verify}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "openvpn login USERNAME password PASSWORD"$}) }
+            it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^crl-verify}) }
           end
 
           context 'when RedHat based machine' do
@@ -1105,8 +1119,8 @@ describe 'openvpn::server' do
               }
             end
 
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^group\s+nobody$}) }
-            it { is_expected.to contain_file('/etc/openvpn/test_server.conf').with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "?login"?$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^group\s+nobody$}) }
+            it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^plugin /usr/lib64/openvpn/plugin/lib/openvpn-auth-pam.so "?login"?$}) }
           end
         end
       end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
     hosts.each do |_host|
       case fact('os.family')
       when 'RedHat'
-        install_module_from_forge_on(hosts_as('agent'), 'stahnma-epel', '>= 1.3.0 < 2.0.0')
+        install_module_from_forge_on(hosts_as('agent'), 'yakatz-epel', '>= 2.0.0 < 3.0.0')
         apply_manifest_on(hosts_as('agent'), 'include ::epel', catch_failures: true)
 
         install_server_packages = %(

--- a/templates/etc-rc.d-openvpn.erb
+++ b/templates/etc-rc.d-openvpn.erb
@@ -1,3 +1,3 @@
 openvpn_<%= @name -%>_enable="YES"
-openvpn_<%= @name -%>_configfile="<%= @etc_directory -%>/openvpn/<%= @name -%>.conf"
-openvpn_<%= @name -%>_dir="<%= @etc_directory -%>/openvpn/<%= @name -%>"
+openvpn_<%= @name -%>_configfile="<%= @server_directory -%>/<%= @name -%>.conf"
+openvpn_<%= @name -%>_dir="<%= @server_directory -%>/<%= @name -%>"

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -1,6 +1,6 @@
 <% unless @remote -%>
 mode server
-client-config-dir <%= @etc_directory -%>/openvpn/<%= @name %>/client-configs
+client-config-dir <%= @server_directory %>/<%= @name %>/client-configs
 <% else -%>
 client
 <% if @ns_cert_type -%>
@@ -33,23 +33,23 @@ crl-verify <%= @extca_ca_crl_file %>
 <%   end -%>
 <% else -%>
 <%- if @_easyrsa_version == '2.0' -%>
-ca <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/ca.crt
-cert <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.crt
-key <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/<%= @ca_common_name %>.key
+ca <%= @server_directory %>/<%= @ca_name %>/keys/ca.crt
+cert <%= @server_directory %>/<%= @ca_name %>/keys/<%= @ca_common_name %>.crt
+key <%= @server_directory %>/<%= @ca_name %>/keys/<%= @ca_common_name %>.key
 <%- else -%>
-ca <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/ca.crt
-cert <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/issued/<%= @ca_common_name %>.crt
-key <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/private/<%= @ca_common_name %>.key
+ca <%= @server_directory %>/<%= @ca_name %>/keys/ca.crt
+cert <%= @server_directory %>/<%= @ca_name %>/keys/issued/<%= @ca_common_name %>.crt
+key <%= @server_directory %>/<%= @ca_name %>/keys/private/<%= @ca_common_name %>.key
 <%- end -%>
 <%   unless @remote -%>
 <%- if @_easyrsa_version == '2.0' -%>
-dh <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
+dh <%= @server_directory %>/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
 <%- else -%>
-dh <%= @etc_directory -%>/openvpn/<%= @ca_name %>/keys/dh.pem
+dh <%= @server_directory %>/<%= @ca_name %>/keys/dh.pem
 <%- end -%>
 <%   end -%>
 <%   unless @remote or !@crl_verify -%>
-crl-verify <%= @etc_directory -%>/openvpn/<%= @ca_name %>/crl.pem
+crl-verify <%= @server_directory %>/<%= @ca_name %>/crl.pem
 <%   end -%>
 <% end -%>
 <% if @proto.include?('tcp') -%>
@@ -173,7 +173,7 @@ client-disconnect "<% unless @client_disconnect =~ /^\// %><%= @_script_dir %>/<
 username-as-common-name
 <% end -%>
 <% if @ldap_enabled == true -%>
-plugin <%= scope.lookupvar('::openvpn::ldap_auth_plugin_location') %> "<%= @etc_directory -%>/openvpn/<%= @name %>/auth/ldap.conf"
+plugin <%= scope.lookupvar('::openvpn::ldap_auth_plugin_location') %> "<%= @server_directory %>/<%= @name %>/auth/ldap.conf"
 <% end -%>
 <% if @client_cert_not_required -%>
 client-cert-not-required
@@ -190,7 +190,7 @@ ping-timer-rem
 tls-auth <%= @extca_tls_auth_key_file %>
 <%   elsif !@extca_enabled -%>
 # tls authentification
-tls-auth <%= @etc_directory -%>/openvpn/<%= @name %>/keys/ta.key
+tls-auth <%= @server_directory %>/<%= @name %>/keys/ta.key
 <%   end -%>
 <%   unless @remote -%>
 key-direction 0
@@ -199,13 +199,13 @@ key-direction 1
 <%   end -%>
 <% end -%>
 <% if @tls_crypt -%>
-tls-crypt <%= @etc_directory -%>/openvpn/<%= @name %>/keys/ta.key
+tls-crypt <%= @server_directory %>/<%= @name %>/keys/ta.key
 <% end -%>
 <% if @fragment != false -%>
 fragment <%= @fragment %>
 <% end -%>
 <% if @secret -%>
-secret <%= @etc_directory -%>/openvpn/<%= @name %>/keys/pre-shared.secret
+secret <%= @server_directory %>/<%= @name %>/keys/pre-shared.secret
 <% end -%>
 
 # Additional custom options

--- a/templates/vars-30.epp
+++ b/templates/vars-30.epp
@@ -12,7 +12,7 @@
 # This variable should point to
 # the top level of the easy-rsa
 # tree.
-export EASY_RSA="<%= $etc_directory -%>/openvpn/<%= $openvpn_server %>/easy-rsa"
+export EASY_RSA="<%= $server_directory -%>/<%= $openvpn_server %>/easy-rsa"
 
 #
 # This variable should point to

--- a/templates/vars.erb
+++ b/templates/vars.erb
@@ -12,7 +12,7 @@
 # This variable should point to
 # the top level of the easy-rsa
 # tree.
-export EASY_RSA="<%= @etc_directory -%>/openvpn/<%= @name %>/easy-rsa"
+export EASY_RSA="<%= @server_directory -%>/<%= @name %>/easy-rsa"
 
 #
 # This variable should point to


### PR DESCRIPTION
Redhat 8 has made a number of changes to openvpn.

- [x] easy-rsa not yet available in EPEL - tracking in https://bugzilla.redhat.com/show_bug.cgi?id=1776676
- [x] Server and client configurations are now expected to be in `/etc/openvpn/server/` and /etc/openvpn/client`. Initial attempt to add default-empty string or `server/` string doesn't pass tests.