### PR TITLE
Repair link to REFERENCE.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The supported Puppet versions are listed in the [metadata.json](metadata.json)
 
 ## REFERENCES
 
-Please see [REFERENCE](REFERENCE.md) for more details.
+Please see [REFERENCE.md](https://github.com/voxpupuli/puppet-openvpn/blob/master/REFERENCE.md) for more details.
 
 ## Example with hiera
 


### PR DESCRIPTION
#### Pull Request (PR) description
This commit simply updates the link to the REFERENCE.md file, so
that it points at the one on github, rather than being a broken
link.

#### This Pull Request (PR) fixes the following issues
n/a