### PR TITLE
name of openssl.cnf changed in easy-rsa 3 or debian buster

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -157,7 +157,7 @@ define openvpn::ca (
       if $openvpn::link_openssl_cnf {
         File["${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf"] {
           ensure => link,
-          target => "${etc_directory}/openvpn/${name}/easy-rsa/openssl-1.0.cnf",
+          target => "${etc_directory}/openvpn/${name}/easy-rsa/openssl-easyrsa.cnf",
           before => Exec["initca ${name}"],
         }
       }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
