### PR TITLE
Update code to set status parameter optional

### DIFF
--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -709,6 +709,21 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^client\-disconnect\s+"#{server_directory}/test_server/scripts/disconnect\.sh"$}) }
         end
 
+        context 'when not using status log' do
+          let(:params) do
+            {
+              'country'       => 'CO',
+              'province'      => 'ST',
+              'city'          => 'Some City',
+              'organization'  => 'example.org',
+              'email'         => 'testemail@example.org',
+              'status_log'    => ''
+            }
+          end
+
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^status}) }
+        end
+
         context 'when not using scripts' do
           let(:params) do
             {

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -83,7 +83,9 @@ user <%= @user %>
 <% if @logfile -%>
 log-append <%= @logfile %>
 <% end -%>
+<% if @status_log != '' -%>
 status <%= @status_log %>
+<% end -%>
 <% if @status_version != '' -%>
 status-version <%= @status_version %>
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Currently the openvpn option called status is mandatory and set with /var/log/openvpn/${name}-status.log as default.
However this parameter is not mandatory in the openvpn config. If this parameter is omitted, every log will be append to openvpn.log.
