### PR TITLE
fix(client): Handle expire value for easyrsa version 3

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -107,6 +107,9 @@ define openvpn::client (
         '3.0': {
           $env_expire = "EASYRSA_CERT_EXPIRE=${expire} EASYRSA_NO_VARS=1"
         }
+        default: {
+          fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0.")
+        }
       }
     } else {
       warning("Custom expiry time ignored: only integer is accepted but ${expire} is given.")

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -100,7 +100,14 @@ define openvpn::client (
 
   if $expire {
     if is_integer($expire) {
-      $env_expire = "KEY_EXPIRE=${expire}"
+      case $openvpn::easyrsa_version {
+        '2.0': {
+          $env_expire = "KEY_EXPIRE=${expire}"
+        }
+        '3.0': {
+          $env_expire = "EASYRSA_CERT_EXPIRE=${expire} EASYRSA_NO_VARS=1"
+        }
+      }
     } else {
       warning("Custom expiry time ignored: only integer is accepted but ${expire} is given.")
     }


### PR DESCRIPTION
#### Pull Request (PR) description
EasyRSA version 3 and above has renamed some environment vars and then source by default the "vars" file. So client.pp allow override the "expire" for certificates but do not handle this change.

You can notice here that the "vars" template handle correctly the change https://github.com/voxpupuli/puppet-openvpn/blob/master/templates/vars-30.epp#L59 but not client.pp