### PR TITLE
Drop CentOS 6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         setfile:
-          - name: CentOS 6
-            value: centos6-64vpnserver.ma{hostname=vpnserver}-centos7-64vpnclienta.a{hostname=vpnclienta}
           - name: CentOS 7
             value: centos7-64vpnserver.ma{hostname=vpnserver}-centos7-64vpnclienta.a{hostname=vpnclienta}
           - name: CentOS 8

--- a/data/family/RedHat/6.yaml
+++ b/data/family/RedHat/6.yaml
@@ -1,2 +1,0 @@
-openvpn::additional_packages: ['easy-rsa','openvpn-auth-ldap']
-openvpn::ldap_auth_plugin_location: '/usr/lib64/openvpn/plugin/lib/openvpn-auth-ldap.so'

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -34,7 +33,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
CentOS 6 is EOL and the tests don't pass anymore. We need to drop
support for it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
