### PR TITLE
add service-notify to scheduled crl_auto_renew exec

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -388,6 +388,7 @@ define openvpn::server (
               cwd      => "${server_directory}/${name}/easy-rsa",
               provider => 'shell',
               schedule => "renew crl.pem schedule on ${name}",
+              notify   => $lnotify,
             }
           }
           '3.0': {
@@ -396,6 +397,7 @@ define openvpn::server (
               cwd      => "${server_directory}/${name}/easy-rsa",
               provider => 'shell',
               schedule => "renew crl.pem schedule on ${name}",
+              notify   => $lnotify,
             }
           }
           default: {


### PR DESCRIPTION
#### Pull Request (PR) description
If using crl_auto_renew and the crl is recreated, the service has to be reloaded, 
otherwise clients can't connect if crl is getting verified. (seen on centos7)

#### This Pull Request (PR) fixes the following issues
no issue created, but i can if it helps
