### PR TITLE
Disable compression and set cipher to AES-256-GCM by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
             value: debian10-64vpnserver.ma{hostname=vpnserver}-debian10-64vpnclienta.a{hostname=vpnclienta}
           - name: Debian 11
             value: debian11-64vpnserver.ma{hostname=vpnserver}-debian11-64vpnclienta.a{hostname=vpnclienta}
-          - name: Ubuntu 16.04
-            value: ubuntu1604-64vpnserver.ma{hostname=vpnserver}-ubuntu1604-64vpnclienta.a{hostname=vpnclienta}
           - name: Ubuntu 18.04
             value: ubuntu1804-64vpnserver.ma{hostname=vpnserver}-ubuntu1804-64vpnclienta.a{hostname=vpnclienta}
           - name: Ubuntu 20.04

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This setting also affects the size of the dhparam file.
 
 ### Cipher
 
-The default data channel cipher is now set to `AES-256-CBC`
+The default data channel cipher is now set to `AES-256-GCM`
 
 ##### Why
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -557,7 +557,7 @@ Data type: `String`
 
 Cipher to use for packet encryption
 
-Default value: `'AES-256-CBC'`
+Default value: `'AES-256-GCM'`
 
 ##### <a name="tls_cipher"></a>`tls_cipher`
 
@@ -1623,7 +1623,7 @@ Data type: `String`
 
 Cipher to use for packet encryption
 
-Default value: `'AES-256-CBC'`
+Default value: `'AES-256-GCM'`
 
 ##### <a name="tls_cipher"></a>`tls_cipher`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -473,11 +473,11 @@ Name of the corresponding openvpn endpoint
 
 ##### <a name="compression"></a>`compression`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 
-Default value: `''`
+Default value: ``undef``
 
 ##### <a name="dev"></a>`dev`
 
@@ -1179,11 +1179,11 @@ Default value: `'server'`
 
 ##### <a name="compression"></a>`compression`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 
-Default value: `''`
+Default value: ``undef``
 
 ##### <a name="dev"></a>`dev`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,7 +18,7 @@
 
 * [`openvpn::ca`](#openvpnca): This define creates the openvpn ca and ssl certificates
 * [`openvpn::client`](#openvpnclient): This define creates client certs for a specified server as well as a tarball that can be directly imported into clients
-* [`openvpn::client_specific_config`](#openvpnclient_specific_config): This feature is explained here: http://openvpn.net/index.php/open-source/documentation/howto.html#policy All the parameters are explained in 
+* [`openvpn::client_specific_config`](#openvpnclient_specific_config): This feature is explained here: http://openvpn.net/index.php/open-source/documentation/howto.html#policy All the parameters are explained in
 * [`openvpn::deploy::client`](#openvpndeployclient): Collect the exported configs for an Host and ensure a running Openvpn Service
 * [`openvpn::deploy::export`](#openvpndeployexport): Prepare all Openvpn-Client-Configs to be exported
 * [`openvpn::revoke`](#openvpnrevoke): This define creates a revocation on a certificate for a specified server.
@@ -32,7 +32,7 @@ This module installs the openvpn service, configures vpn endpoints, generates cl
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 class { 'openvpn':
@@ -222,7 +222,7 @@ Base profile
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 include openvpn::deploy::prepare
@@ -260,7 +260,7 @@ This define creates the openvpn ca and ssl certificates
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::ca {
@@ -415,7 +415,7 @@ This define creates client certs for a specified server as well as a tarball tha
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client {
@@ -475,9 +475,9 @@ Name of the corresponding openvpn endpoint
 
 Data type: `String`
 
-Which compression algorithim to use
+Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 
-Default value: `'comp-lzo'`
+Default value: `''`
 
 ##### <a name="dev"></a>`dev`
 
@@ -750,7 +750,7 @@ All the parameters are explained in the openvpn documentation http://openvpn.net
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client_specific_config {
@@ -861,7 +861,7 @@ Collect the exported configs for an Host and ensure a running Openvpn Service
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::deploy::client { 'test-client':
@@ -896,7 +896,7 @@ Prepare all Openvpn-Client-Configs to be exported
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::deploy::export { 'test-client':
@@ -931,7 +931,7 @@ This define creates a revocation on a certificate for a specified server.
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client {
@@ -940,7 +940,7 @@ openvpn::client {
 }
 ```
 
-##### 
+#####
 
 ```puppet
 openvpn::revoke {
@@ -1181,9 +1181,9 @@ Default value: `'server'`
 
 Data type: `String`
 
-Which compression algorithim to use
+Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 
-Default value: `'comp-lzo'`
+Default value: `''`
 
 ##### <a name="dev"></a>`dev`
 

--- a/lib/facter/easyrsa.rb
+++ b/lib/facter/easyrsa.rb
@@ -12,7 +12,7 @@ Facter.add(:easyrsa) do
       binaryv3 = '/usr/share/easy-rsa/3/easyrsa'
     when %r{Ubuntu|Debian}
       case operatingsystemrelease
-      when %r{8|9|10|11|16.04|18.04|20.04}
+      when %r{9|10|11|18.04|20.04}
         binaryv2 = '/usr/share/easy-rsa/pkitool'
         binaryv3 = '/usr/share/easy-rsa/easyrsa'
       else

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -46,7 +46,7 @@
 #
 define openvpn::client (
   String $server,
-  String $compression                                  = '',
+  Optional[String[1]] $compression                     = undef,
   Enum['tap', 'tun'] $dev                              = 'tun',
   Integer $mute                                        = 20,
   Boolean $mute_replay_warnings                        = true,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -2,7 +2,7 @@
 # @summary This define creates client certs for a specified server as well as a tarball that can be directly imported into clients
 #
 # @param server Name of the corresponding openvpn endpoint
-# @param compression Which compression algorithim to use
+# @param compression Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 # @param dev Device method
 # @param mute Set log mute level
 # @param mute_replay_warnings Silence duplicate packet warnings (common on wireless networks)
@@ -46,7 +46,7 @@
 #
 define openvpn::client (
   String $server,
-  String $compression                                  = 'comp-lzo',
+  String $compression                                  = '',
   Enum['tap', 'tun'] $dev                              = 'tun',
   Integer $mute                                        = 20,
   Boolean $mute_replay_warnings                        = true,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -60,7 +60,7 @@ define openvpn::client (
   Enum['none', 'nointeract', 'interact'] $auth_retry   = 'none',
   String $verb                                         = '3',
   Boolean $pam                                         = false,
-  String $cipher                                       = 'AES-256-CBC',
+  String $cipher                                       = 'AES-256-GCM',
   String $tls_cipher                                   = 'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256',
   Boolean $authuserpass                                = false,
   Hash $setenv                                         = {},

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,10 +7,10 @@
 # @param organization Organization to be used for the SSL certificate, mandatory for server mode.
 # @param email Email address to be used for the SSL certificate, mandatory for server mode.
 # @param remote List of OpenVPN endpoints to connect to.
-# @param remote_random_hostname OpenVPN will prepend a random string (6 bytes, 12 hex characters) to hostname to prevent DNS caching. For example, "foo.example.com" would be modified to "<random-chars>.foo.example.com". 
+# @param remote_random_hostname OpenVPN will prepend a random string (6 bytes, 12 hex characters) to hostname to prevent DNS caching. For example, "foo.example.com" would be modified to "<random-chars>.foo.example.com".
 # @param remote_random When multiple ${remote} address/ports are specified, initially randomize the order of the list as a kind of basic load-balancing measure.
 # @param common_name Common name to be used for the SSL certificate
-# @param compression Which compression algorithim to use
+# @param compression Which compression algorithm to use. This parameter is deprecated in OpenVPN 2.5.
 # @param dev TUN/TAP virtual network device
 # @param user Group to drop privileges to after startup
 # @param group User to drop privileges to after startup
@@ -151,7 +151,7 @@ define openvpn::server (
   Boolean $remote_random_hostname                                   = false,
   Boolean $remote_random                                            = false,
   String $common_name                                               = 'server',
-  String $compression                                               = 'comp-lzo',
+  String $compression                                               = '',
   String $dev                                                       = 'tun0',
   String $user                                                      = 'nobody',
   Optional[String] $group                                           = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -151,7 +151,7 @@ define openvpn::server (
   Boolean $remote_random_hostname                                   = false,
   Boolean $remote_random                                            = false,
   String $common_name                                               = 'server',
-  String $compression                                               = '',
+  Optional[String[1]] $compression                                  = undef,
   String $dev                                                       = 'tun0',
   String $user                                                      = 'nobody',
   Optional[String] $group                                           = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -212,7 +212,7 @@ define openvpn::server (
   String $key_name                                                  = '',
   String $key_ou                                                    = '',
   String $verb                                                      = '',
-  String $cipher                                                    = 'AES-256-CBC',
+  String $cipher                                                    = 'AES-256-GCM',
   String $tls_cipher                                                = 'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256',
   Boolean $persist_key                                              = false,
   Boolean $persist_tun                                              = false,

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]

--- a/spec/classes/openvpn_init_spec.rb
+++ b/spec/classes/openvpn_init_spec.rb
@@ -10,7 +10,7 @@ describe 'openvpn', type: :class do
       os_name = facts[:os]['name']
       os_release = facts[:os]['release']['major']
       case "#{os_name}-#{os_release}"
-      when 'CentOS-6', 'RedHat-6', %r{FreeBSD}
+      when %r{FreeBSD}
         let(:facts) do
           facts
         end

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -144,7 +144,7 @@ describe 'openvpn::client', type: :define do
             'nobind'                => false,
             'persist_key'           => false,
             'persist_tun'           => false,
-            'cipher'                => 'AES-256-CBC',
+            'cipher'                => 'AES-256-GCM',
             'tls_cipher'            => 'TLS-DHE-RSA-WITH-AES-256-CBC-SHA',
             'port'                  => '123',
             'proto'                 => 'udp',
@@ -180,7 +180,7 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^auth-retry\s+interact$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^setenv\s+CLIENT_CERT\s+0$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^setenv_safe\s+FORWARD_COMPATIBLE\s+1$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher\s+AES-256-CBC$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher\s+AES-256-GCM$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^tls-client$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verify-x509-name\s+"test_server"\s+name$}) }
@@ -200,7 +200,7 @@ describe 'openvpn::client', type: :define do
       context 'omitting the cipher key' do
         let(:params) { { 'server' => 'test_server' } }
 
-        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher AES-256-CBC$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^cipher AES-256-GCM$}) }
       end
 
       context 'should fail if specifying an openvpn::server with extca_enabled=true' do

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -117,7 +117,6 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^dev\s+tun$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^proto\s+tcp$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote\s+foo.example.com\s+1194$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^comp-lzo$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^resolv-retry\s+infinite$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^nobind$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^persist-key$}) }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -670,7 +670,7 @@ describe 'openvpn::server' do
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^secret}) }
 
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{verb}) }
-          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{cipher AES-256-CBC}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{cipher AES-256-GCM}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-key}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-tun}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^duplicate-cn$}) }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -658,7 +658,7 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^proto\s+tcp-server$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-server$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port\s+1194$}) }
-          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^comp-lzo$}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^comp-lzo$}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^log\-append\s+test_server\/openvpn\.log$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^status\s+/var/log/openvpn/test_server-status\.log$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dev\s+tun0$}) }

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -5,7 +5,7 @@ proto <%= @proto %>
 <% @remote_host.each do |item| -%>
 remote <%= item %> <%= @port %>
 <% end -%>
-<% if @compression != '' -%>
+<% if @compression -%>
 <%= @compression %>
 <% end -%>
 resolv-retry <%= @resolv_retry %>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -75,7 +75,7 @@ tls-server
 <% if @tls_client -%>
 tls-client
 <% end -%>
-<% if @compression != '' -%>
+<% if @compression -%>
 <%= @compression %>
 <% end -%>
 group <%= @group_to_set %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Since https://github.com/voxpupuli/puppet-openvpn/pull/410 would introduce a breaking change, I would recommend to include this breaking change, too.

OpenVPN is going to remove the compression feature. I would disable compression by default. That results that new OpenVPN servers are future proof by default.

OpenVPN not longer recommends to define a cipher, since OpenVPN use (and enforce in upcoming version) cipher negotiation. For 2.4 compability, the 'AES-256-CBC' isn't a good default anymore. Using 'AES-256-GCM' as default is much better here, since it's the default cipher of the cipher negotiation.

> Sep 16 22:52:56 PI openvpn[961]: DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (AES-256-GCM:AES-128-GCM). Future OpenVPN version will ignore --cipher for cipher negotiations. Add 'AES-256-CBC' to --data-ciphers or change --cipher 'AES-256-CBC' to --data-ciphers-fallback 'AES-256-CBC' to silence this warning.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
