### PR TITLE
Drop Ubuntu 16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
             value: debian10-64vpnserver.ma{hostname=vpnserver}-debian10-64vpnclienta.a{hostname=vpnclienta}
           - name: Debian 11
             value: debian11-64vpnserver.ma{hostname=vpnserver}-debian11-64vpnclienta.a{hostname=vpnclienta}
-          - name: Ubuntu 16.04
-            value: ubuntu1604-64vpnserver.ma{hostname=vpnserver}-ubuntu1604-64vpnclienta.a{hostname=vpnclienta}
           - name: Ubuntu 18.04
             value: ubuntu1804-64vpnserver.ma{hostname=vpnserver}-ubuntu1804-64vpnclienta.a{hostname=vpnclienta}
           - name: Ubuntu 20.04

--- a/lib/facter/easyrsa.rb
+++ b/lib/facter/easyrsa.rb
@@ -12,7 +12,7 @@ Facter.add(:easyrsa) do
       binaryv3 = '/usr/share/easy-rsa/3/easyrsa'
     when %r{Ubuntu|Debian}
       case operatingsystemrelease
-      when %r{8|9|10|11|16.04|18.04|20.04}
+      when %r{9|10|11|18.04|20.04}
         binaryv2 = '/usr/share/easy-rsa/pkitool'
         binaryv3 = '/usr/share/easy-rsa/easyrsa'
       else

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]

--- a/spec/classes/openvpn_init_spec.rb
+++ b/spec/classes/openvpn_init_spec.rb
@@ -10,7 +10,7 @@ describe 'openvpn', type: :class do
       os_name = facts[:os]['name']
       os_release = facts[:os]['release']['major']
       case "#{os_name}-#{os_release}"
-      when 'CentOS-6', 'RedHat-6', %r{FreeBSD}
+      when %r{FreeBSD}
         let(:facts) do
           facts
         end


### PR DESCRIPTION
From: https://github.com/voxpupuli/puppet-openvpn/pull/412#issuecomment-922243167

> We can drop it along with Debian 9.

I wouldn't. https://wiki.debian.org/LTS. It is still supported until 2022.

~~I'm going to modify the actions, since the logic will be changed in modulesync 4.2. See: https://github.com/voxpupuli/puppet-openvpn/pull/411~~ Looks like it's not ready. (tests failing)