### PR TITLE
Replace ns_cert_type with remote_cert_tls (**client config regeneration needed**)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,7 +18,7 @@
 
 * [`openvpn::ca`](#openvpnca): This define creates the openvpn ca and ssl certificates
 * [`openvpn::client`](#openvpnclient): This define creates client certs for a specified server as well as a tarball that can be directly imported into clients
-* [`openvpn::client_specific_config`](#openvpnclient_specific_config): This feature is explained here: http://openvpn.net/index.php/open-source/documentation/howto.html#policy All the parameters are explained in 
+* [`openvpn::client_specific_config`](#openvpnclient_specific_config): This feature is explained here: http://openvpn.net/index.php/open-source/documentation/howto.html#policy All the parameters are explained in
 * [`openvpn::deploy::client`](#openvpndeployclient): Collect the exported configs for an Host and ensure a running Openvpn Service
 * [`openvpn::deploy::export`](#openvpndeployexport): Prepare all Openvpn-Client-Configs to be exported
 * [`openvpn::revoke`](#openvpnrevoke): This define creates a revocation on a certificate for a specified server.
@@ -32,7 +32,7 @@ This module installs the openvpn service, configures vpn endpoints, generates cl
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 class { 'openvpn':
@@ -222,7 +222,7 @@ Base profile
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 include openvpn::deploy::prepare
@@ -260,7 +260,7 @@ This define creates the openvpn ca and ssl certificates
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::ca {
@@ -415,7 +415,7 @@ This define creates client certs for a specified server as well as a tarball tha
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client {
@@ -462,7 +462,6 @@ The following parameters are available in the `openvpn::client` defined type:
 * [`readme`](#readme)
 * [`pull`](#pull)
 * [`server_extca_enabled`](#server_extca_enabled)
-* [`ns_cert_type`](#ns_cert_type)
 * [`remote_cert_tls`](#remote_cert_tls)
 
 ##### <a name="server"></a>`server`
@@ -727,21 +726,13 @@ Turn this on if you are using an external CA solution, like FreeIPA. Use this in
 
 Default value: ``false``
 
-##### <a name="ns_cert_type"></a>`ns_cert_type`
-
-Data type: `Boolean`
-
-Enable or disable use of ns-cert-type. Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
-
-Default value: ``true``
-
 ##### <a name="remote_cert_tls"></a>`remote_cert_tls`
 
 Data type: `Boolean`
 
 Enable or disable use of remote-cert-tls used with client configuration
 
-Default value: ``false``
+Default value: ``true``
 
 ### <a name="openvpnclient_specific_config"></a>`openvpn::client_specific_config`
 
@@ -750,7 +741,7 @@ All the parameters are explained in the openvpn documentation http://openvpn.net
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client_specific_config {
@@ -861,7 +852,7 @@ Collect the exported configs for an Host and ensure a running Openvpn Service
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::deploy::client { 'test-client':
@@ -896,7 +887,7 @@ Prepare all Openvpn-Client-Configs to be exported
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::deploy::export { 'test-client':
@@ -931,7 +922,7 @@ This define creates a revocation on a certificate for a specified server.
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 openvpn::client {
@@ -940,7 +931,7 @@ openvpn::client {
 }
 ```
 
-##### 
+#####
 
 ```puppet
 openvpn::revoke {
@@ -1097,7 +1088,6 @@ The following parameters are available in the `openvpn::server` defined type:
 * [`extca_dh_file`](#extca_dh_file)
 * [`extca_tls_auth_key_file`](#extca_tls_auth_key_file)
 * [`autostart`](#autostart)
-* [`ns_cert_type`](#ns_cert_type)
 * [`remote_cert_tls`](#remote_cert_tls)
 * [`nobind`](#nobind)
 * [`secret`](#secret)
@@ -1857,21 +1847,13 @@ Enable autostart for server if openvpn::autostart_all is false.
 
 Default value: ``undef``
 
-##### <a name="ns_cert_type"></a>`ns_cert_type`
-
-Data type: `Boolean`
-
-Enable or disable use of ns-cert-type for the session. Generally used with client configuration Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
-
-Default value: ``true``
-
 ##### <a name="remote_cert_tls"></a>`remote_cert_tls`
 
 Data type: `Boolean`
 
 Enable or disable use of remote-cert-tls for the session. Generally used with client configuration
 
-Default value: ``false``
+Default value: ``true``
 
 ##### <a name="nobind"></a>`nobind`
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -34,7 +34,6 @@
 # @param readme Text to place in a README file which is included in download-configs archive.
 # @param pull Allow server to push options like dns or routes
 # @param server_extca_enabled Turn this on if you are using an external CA solution, like FreeIPA. Use this in Combination with exported_ressourced, since they don't have Access to the Serverconfig
-# @param ns_cert_type Enable or disable use of ns-cert-type. Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
 # @param remote_cert_tls Enable or disable use of remote-cert-tls used with client configuration
 #
 # @example
@@ -78,8 +77,7 @@ define openvpn::client (
   Optional[String] $readme                             = undef,
   Boolean $pull                                        = false,
   Boolean $server_extca_enabled                        = false,
-  Boolean $ns_cert_type                                = true,
-  Boolean $remote_cert_tls                             = false,
+  Boolean $remote_cert_tls                             = true,
 ) {
   if $pam {
     warning('Using $pam is deprecated. Use $authuserpass instead!')

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,7 +7,7 @@
 # @param organization Organization to be used for the SSL certificate, mandatory for server mode.
 # @param email Email address to be used for the SSL certificate, mandatory for server mode.
 # @param remote List of OpenVPN endpoints to connect to.
-# @param remote_random_hostname OpenVPN will prepend a random string (6 bytes, 12 hex characters) to hostname to prevent DNS caching. For example, "foo.example.com" would be modified to "<random-chars>.foo.example.com". 
+# @param remote_random_hostname OpenVPN will prepend a random string (6 bytes, 12 hex characters) to hostname to prevent DNS caching. For example, "foo.example.com" would be modified to "<random-chars>.foo.example.com".
 # @param remote_random When multiple ${remote} address/ports are specified, initially randomize the order of the list as a kind of basic load-balancing measure.
 # @param common_name Common name to be used for the SSL certificate
 # @param compression Which compression algorithim to use
@@ -95,7 +95,6 @@
 # @param extca_dh_file External CA: Path to your Dillie-Hellman parameter file. You will need to create one yourself. Make sure key-size matches the public key size of your CA-issued server certificate. Like this: openssl dhparam -out /path/to/dh.pem 2048 Note: This is only required if you are enabling $tls_server.
 # @param extca_tls_auth_key_file External CA: If you are enabling $extca_enabled and $tls_auth, you will also need to create  the tls-auth key file and specify its location here. The file can be created like this: openvpn --genkey --secret /path/to/ta.key. Note: you will need to distribute this file to your clients as well.
 # @param autostart  Enable autostart for server if openvpn::autostart_all is false.
-# @param ns_cert_type Enable or disable use of ns-cert-type for the session. Generally used with client configuration Deprecated in OpenVPN 2.4 and replaced with remote-cert-tls
 # @param remote_cert_tls Enable or disable use of remote-cert-tls for the session. Generally used with client configuration
 # @param nobind Whether or not to bind to a specific port number.#
 # @param secret A pre-shared static key.
@@ -237,8 +236,7 @@ define openvpn::server (
   Optional[String] $extca_dh_file                                   = undef,
   Optional[String] $extca_tls_auth_key_file                         = undef,
   Optional[Boolean] $autostart                                      = undef,
-  Boolean $ns_cert_type                                             = true,
-  Boolean $remote_cert_tls                                          = false,
+  Boolean $remote_cert_tls                                          = true,
   Boolean $nobind                                                   = false,
   Optional[String] $secret                                          = undef,
   Hash[String, Hash] $scripts                                       = {},

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -123,7 +123,7 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^persist-key$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^persist-tun$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^mute-replay-warnings$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^ns\-cert\-type\s+server$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote-cert-tls\s+server$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^verb\s+3$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^mute\s+20$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^auth-retry\s+none$}) }
@@ -161,8 +161,7 @@ describe 'openvpn::client', type: :define do
             'rcvbuf'                => 393_215,
             'readme'                => 'readme text',
             'pull'                  => true,
-            'ns_cert_type'          => false,
-            'remote_cert_tls'       => true
+            'remote_cert_tls'       => false
           }
         end
 
@@ -189,7 +188,7 @@ describe 'openvpn::client', type: :define do
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^rcvbuf\s+393215$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/README").with_content(%r{^readme text$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^pull$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote-cert-tls\s+server$}) }
+        it { is_expected.not_to contain_file("#{server_directory}/test_server/download-configs/test_client/test_client.conf").with_content(%r{^remote-cert-tls\s+server$}) }
       end
 
       context 'test tls_crypt' do

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -227,7 +227,7 @@ describe 'openvpn::server' do
         }
         it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^server-poll-timeout\s+1$}) }
         it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ping-timer-rem$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ns-cert-type server}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^remote-cert-tls server}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^mode\s+server$}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client-config-dir}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^dh}) }
@@ -278,7 +278,7 @@ describe 'openvpn::server' do
         it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^remote-random$}) }
         it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^server-poll-timeout\s+1$}) }
         it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ping-timer-rem$}) }
-        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^ns-cert-type server}) }
+        it { is_expected.to contain_file("#{server_directory}/test_client.conf").with_content(%r{^remote-cert-tls server}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^mode\s+server$}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^client-config-dir}) }
         it { is_expected.not_to contain_file("#{server_directory}/test_client.conf").with_content(%r{^dh}) }
@@ -674,7 +674,7 @@ describe 'openvpn::server' do
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-key}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{persist-tun}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^duplicate-cn$}) }
-          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^ns-cert-type server}) }
+          it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^remote-cert-tls server}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^tls-auth}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^fragment}) }
           it { is_expected.not_to contain_file("#{server_directory}/test_server.conf").with_content(%r{^port-share}) }

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -31,9 +31,7 @@ tls-cipher <%= @tls_cipher %>
 <% if @mute_replay_warnings -%>
 mute-replay-warnings
 <% end -%>
-<% if @ns_cert_type -%>
-ns-cert-type server
-<% elsif @remote_cert_tls -%>
+<% if @remote_cert_tls -%>
 remote-cert-tls server
 <% end -%>
 <% if @sndbuf -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -3,9 +3,7 @@ mode server
 client-config-dir <%= @server_directory %>/<%= @name %>/client-configs
 <% else -%>
 client
-<% if @ns_cert_type -%>
-ns-cert-type server
-<% elsif @remote_cert_tls -%>
+<% if @remote_cert_tls -%>
 remote-cert-tls server
 <% end -%>
 <% @remote.to_a.each do |rem| -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#Option:--ns-cert-type

The OpenVPN parameter `--ns-cert-type` is deprecated since some OpenVPN version. `--remote-cert-tls` is a drop-in replacement. Current OpenVPN versions map `--ns-cert-type` to `--remote-cert-tls` and raise a deprecation warning.

We could drop `--ns-cert-type` (default to true in this module) and set `--remote-cert-tls` (default to false in this module) to true.

This is a breaking change, since client configs needs to be re-generated.

**Note for affected users**

You can still define `ns-cert-type` through `custom_options`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
