### PR TITLE
Unbreak vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,47 @@ Installation, configuration and starting the OpenVPN client in a configured node
   }
 ```
 
+## Experimenting and developing in Vagrant
+
+This project includes a Vagrantfile which allows you to easily develop this
+module or try it out. The prerequisites are [Vagrant](https://www.vagrantup.com/)
+and [VirtualBox](https://www.virtualbox.org/).
+
+To bring up the OpenVPN server VM:
+
+    vagrant up server_ubuntu
+
+To bring up the OpenVPN client VM:
+
+    vagrant up client_ubuntu
+
+Client's OpenVPN configuration is generated on the server, but it needs to be
+deployed to the client manually as exported resources are not available in
+Vagrant. To get the client config from server:
+
+    vagrant ssh server_ubuntu
+    sudo -i
+    cp /etc/openvpn/winterthur/download-configs/client1.ovpn /vagrant/
+    exit
+
+To copy it to the client:
+
+    vagrant ssh client_ubuntu
+    sudo -i
+    mv /vagrant/client1.ovpn /etc/openvpn/client/client1.conf
+
+To connect directly with OpenVPN:
+
+    openvpn --config /etc/openvpn/client/client1.conf
+
+To connect with systemd:
+
+    systemctl start openvpn-client@client1
+
+To test connectivity between client and server:
+
+    ping 10.200.200.1
+
 ##### References
 
 * The readme file of [github.com/Angristan/OpenVPN-install](https://github.com/Angristan/OpenVPN-install/tree/f47fc795d5e2d53f74431aadc58ef9de5784103a) outlines some of reasoning behind

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,14 +25,14 @@ Vagrant::Config.run(2) do |config|
 
   config.vm.define :server_ubuntu do |c|
     c.vm.hostname = 'server'
-    c.vm.box = 'ubuntu/trusty64'
+    c.vm.box = 'ubuntu/focal64'
     server_config c
     c.vm.network :private_network, ip: '192.168.61.10'
   end
 
   config.vm.define :client_ubuntu do |c|
     c.vm.hostname = 'client'
-    c.vm.box = 'ubuntu/trusty64'
+    c.vm.box = 'ubuntu/focal64'
     client_config c
     c.vm.network :private_network, ip: '192.168.61.20'
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,13 +27,13 @@ Vagrant::Config.run(2) do |config|
     c.vm.hostname = 'server'
     c.vm.box = 'ubuntu/trusty64'
     server_config c
-    c.vm.network :private_network, ip: '10.255.255.10'
+    c.vm.network :private_network, ip: '192.168.61.10'
   end
 
   config.vm.define :client_ubuntu do |c|
     c.vm.hostname = 'client'
     c.vm.box = 'ubuntu/trusty64'
     client_config c
-    c.vm.network :private_network, ip: '10.255.255.20'
+    c.vm.network :private_network, ip: '192.168.61.20'
   end
 end

--- a/vagrant/provision_module.sh
+++ b/vagrant/provision_module.sh
@@ -3,10 +3,15 @@
 set -e
 
 if [ ! -f /module-installed ]; then
-  apt-get update
-  apt-get install -y ruby-dev git
+  wget https://apt.puppet.com/puppet7-release-focal.deb
+  dpkg -i puppet7-release-focal.deb
 
-  gem install librarian-puppet --no-rdoc --no-ri
+  apt-get update
+  apt-get install -y ruby-dev git puppet-agent
+
+  export PATH=$PATH:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin
+
+  gem install librarian-puppet --no-document
 
   cp /vagrant/vagrant/Puppetfile /tmp
   cd /tmp && librarian-puppet install --verbose

--- a/vagrant/server.pp
+++ b/vagrant/server.pp
@@ -5,6 +5,7 @@ node default {
     city         => 'Winterthur',
     organization => 'example.org',
     email        => 'root@example.org',
+    local        => '192.168.61.10',
     server       => '10.200.200.0 255.255.255.0',
   }
 

--- a/vagrant/server.pp
+++ b/vagrant/server.pp
@@ -9,7 +9,8 @@ node default {
   }
 
   openvpn::client { 'client1':
-    server => 'winterthur';
+    server      => 'winterthur',
+    remote_host => '192.168.61.10',
   }
 
   openvpn::client_specific_config { 'client1':
@@ -18,14 +19,16 @@ node default {
   }
 
   openvpn::client { 'client2':
-    server => 'winterthur';
+    server      => 'winterthur',
+    remote_host => '192.168.61.10',
   }
 
   openvpn::client { 'client3':
-    server => 'winterthur';
+    server      => 'winterthur',
+    remote_host => '192.168.61.10',
   }
 
   openvpn::revoke { 'client3':
-    server => 'winterthur';
+    server => 'winterthur',
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR unbreak the Vagrant environment which no longer worked because Ubuntu 16.04 was too old and installation of librarian-puppet failed. Instead of trying to fix an EOL operating system migrate to Ubuntu 20.04 instead and fix all the things that need fixing.

Vagrant now makes use of Puppet 7 from Puppetlabs. This avoids some warnings triggered by the default, EOL version of Puppet (5.5) in Ubuntu 20.04.

Some of the issues that were identified were generic and not related to the operating system upgrade.