### PR TITLE
Support custom_options in client_specific_config

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -738,6 +738,7 @@ The following parameters are available in the `openvpn::client_specific_config` 
 * [`ifconfig_ipv6`](#ifconfig_ipv6)
 * [`dhcp_options`](#dhcp_options)
 * [`redirect_gateway`](#redirect_gateway)
+* [`custom_options`](#custom_options)
 * [`ensure`](#ensure)
 * [`manage_client_configs`](#manage_client_configs)
 
@@ -802,6 +803,14 @@ Data type: `Boolean`
 Redirect all traffic to gateway
 
 Default value: ``false``
+
+##### <a name="custom_options"></a>`custom_options`
+
+Data type: `Hash`
+
+Hash of additional options to append to the configuration file.
+
+Default value: `{}`
 
 ##### <a name="ensure"></a>`ensure`
 

--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -11,6 +11,7 @@
 # @param ifconfig_ipv6 IPv6 configuration to push to the client.
 # @param dhcp_options DHCP options to push to the client.
 # @param redirect_gateway Redirect all traffic to gateway
+# @param custom_options Hash of additional options to append to the configuration file.
 # @param ensure Sets the client specific configuration file status (present or absent)
 # @param manage_client_configs Manage dependencies on Openvpn::Client ressources
 #
@@ -32,6 +33,7 @@ define openvpn::client_specific_config (
   Optional[String[1]] $ifconfig_ipv6 = undef,
   Array[String[1]]  $dhcp_options    = [],
   Boolean $redirect_gateway          = false,
+  Hash $custom_options               = {},
   Boolean $manage_client_configs     = true,
 ) {
   if $manage_client_configs {

--- a/spec/defines/openvpn_client_specific_config_spec.rb
+++ b/spec/defines/openvpn_client_specific_config_spec.rb
@@ -58,6 +58,7 @@ describe 'openvpn::client_specific_config', type: :define do
             ifconfig_ipv6: '2001:db8:0:123::2/64 2001:db8:0:123::1',
             route: ['10.200.100.0 255.255.255.0 10.10.10.1'],
             dhcp_options: ['DNS 8.8.8.8'],
+            custom_options: { 'this' => 'that' },
             redirect_gateway: true
           }
         end
@@ -69,6 +70,7 @@ describe 'openvpn::client_specific_config', type: :define do
         it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "dhcp-option DNS 8.8.8.8"$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "redirect-gateway def1"$}) }
         it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^push "route 10.200.100.0 255.255.255.0 10.10.10.1"$}) }
+        it { is_expected.to contain_file("#{server_directory}/test_server/client-configs/test_client").with_content(%r{^this that$}) }
       end
     end
   end

--- a/templates/client_specific_config.erb
+++ b/templates/client_specific_config.erb
@@ -19,4 +19,7 @@ push "redirect-gateway def1"
 <% @route.each do |route| -%>
 push "route <%= route %>"
 <% end -%>
+<% @custom_options.each_pair do |key, value| -%>
+<%= key %> <%= value %>
+<% end -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
Currently, the openvpn::client and openvpn::server classes both support
custom_options.  Modify openvpn::client_specific_config to also support
custom_options.

#### This Pull Request (PR) fixes the following issues
(no issues)
