### PR TITLE
Add support for easyrsa X509 DN mode 'cn_only'

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -237,6 +237,7 @@ openvpn::ca {
 
 The following parameters are available in the `openvpn::ca` defined type:
 
+* [`dn_mode`](#dn_mode)
 * [`country`](#country)
 * [`province`](#province)
 * [`city`](#city)
@@ -256,6 +257,14 @@ The following parameters are available in the `openvpn::ca` defined type:
 * [`tls_auth`](#tls_auth)
 * [`tls_static_key`](#tls_static_key)
 * [`crl_days`](#crl_days)
+
+##### <a name="dn_mode"></a>`dn_mode`
+
+Data type: `Enum['org','cn_only']`
+
+EasyRSA X509 DN mode.
+
+Default value: `'org'`
 
 ##### <a name="country"></a>`country`
 
@@ -933,6 +942,7 @@ openvpn::server { 'zurich':
 
 The following parameters are available in the `openvpn::server` defined type:
 
+* [`dn_mode`](#dn_mode)
 * [`country`](#country)
 * [`province`](#province)
 * [`city`](#city)
@@ -1038,6 +1048,14 @@ The following parameters are available in the `openvpn::server` defined type:
 * [`scripts`](#scripts)
 * [`custom_options`](#custom_options)
 * [`fragment`](#fragment)
+
+##### <a name="dn_mode"></a>`dn_mode`
+
+Data type: `Enum['org','cn_only']`
+
+EasyRSA X509 DN mode.
+
+Default value: `'org'`
 
 ##### <a name="country"></a>`country`
 

--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -31,7 +31,7 @@ define openvpn::revoke (
 
   $renew_command = $openvpn::easyrsa_version ? {
     '2.0'   => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${server_directory}/${server}/crl.pem -config ${server_directory}/${server}/easy-rsa/openssl.cnf",
-    '3.0'   => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${server_directory}/${server}/crl.pem -config ${server_directory}/${server}/easy-rsa/openssl.cnf",
+    '3.0'   => './easyrsa gen-crl',
     default => fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0."),
   }
 
@@ -53,5 +53,14 @@ define openvpn::revoke (
     cwd         => "${server_directory}/${server}/easy-rsa",
     provider    => 'shell',
     refreshonly => true,
+  }
+
+  if ($openvpn::easyrsa_version == '3.0') {
+    exec { "copy renewed crl.pem to ${name} keys directory because of revocation of ${name}":
+      command     => "cp ${server_directory}/${server}/easy-rsa/keys/crl.pem ${server_directory}/${server}/crl.pem",
+      subscribe   => Exec["renew crl.pem on ${server} because of revocation of ${name}"],
+      provider    => 'shell',
+      refreshonly => true,
+    }
   }
 }

--- a/spec/acceptance/openvpn_spec.rb
+++ b/spec/acceptance/openvpn_spec.rb
@@ -195,7 +195,7 @@ end
 if easy_rsa_version == '3.0'
   describe 'server defined type w/ easy-rsa 3.0' do
     dev = 'tun1'
-    server_name = 'test_openvpn_server_ec'
+    server_name = 'test_openvpn_server_ec_dn_mode'
     port = 1195
     management_port = 7506
 
@@ -204,11 +204,7 @@ if easy_rsa_version == '3.0'
         pp = %(
         openvpn::server { '#{server_name}':
           dev             => '#{dev}',
-          country         => 'CO',
-          province        => 'ST',
-          city            => 'A city',
-          organization    => 'FOO',
-          email           => 'bar@foo.org',
+          dn_mode         => 'cn_only',
           ssl_key_algo    => 'ec',
           ssl_key_curve   => 'secp521r1',
           ecdh_curve      => 'secp521r1',
@@ -229,11 +225,7 @@ if easy_rsa_version == '3.0'
         pp = %(
         openvpn::server { '#{server_name}':
           dev             => '#{dev}',
-          country         => 'CO',
-          province        => 'ST',
-          city            => 'A city',
-          organization    => 'FOO',
-          email           => 'bar@foo.org',
+          dn_mode         => 'cn_only',
           ssl_key_algo    => 'ec',
           ssl_key_curve   => 'secp521r1',
           ecdh_curve      => 'secp521r1',
@@ -262,11 +254,7 @@ if easy_rsa_version == '3.0'
         pp = %(
         openvpn::server { '#{server_name}':
           dev             => '#{dev}',
-          country         => 'CO',
-          province        => 'ST',
-          city            => 'A city',
-          organization    => 'FOO',
-          email           => 'bar@foo.org',
+          dn_mode         => 'cn_only',
           ssl_key_algo    => 'ec',
           ssl_key_curve   => 'secp521r1',
           ecdh_curve      => 'secp521r1',
@@ -308,6 +296,7 @@ if easy_rsa_version == '3.0'
         it { is_expected.to contain 'export EASYRSA_ALGO=ec' }
         it { is_expected.to contain 'export EASYRSA_CURVE=secp521r1' }
         it { is_expected.to contain 'export EASYRSA_DIGEST=sha256' }
+        it { is_expected.to contain 'export EASYRSA_DN="cn_only"' }
       end
 
       describe file(server_crt.to_s), :crtFile do
@@ -334,7 +323,7 @@ if easy_rsa_version == '3.0'
 
       describe file("#{server_directory}/#{server_name}/easy-rsa/keys/issued/#{server_name}-vpnclienta.crt") do
         it { is_expected.to be_file }
-        it { is_expected.to contain 'Issuer: C=CO, ST=ST, L=A city, O=FOO, ' }
+        it { is_expected.to contain 'Issuer: CN=openvpn-server CA' }
       end
 
       describe file("#{server_directory}/#{server_name}/easy-rsa/keys/index.txt") do

--- a/spec/defines/openvpn_ca_spec.rb
+++ b/spec/defines/openvpn_ca_spec.rb
@@ -43,11 +43,6 @@ describe 'openvpn::ca', type: :define do
           it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with(mode: '0550') }
 
           it {
-            is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/keys/crl.pem").
-              with(ensure: 'link', target: "#{server_directory}/test_server/crl.pem")
-          }
-
-          it {
             is_expected.to contain_file("#{server_directory}/test_server/keys").
               with(ensure: 'link', target: "#{server_directory}/test_server/easy-rsa/keys")
           }
@@ -69,6 +64,7 @@ describe 'openvpn::ca', type: :define do
         context 'creating a ca setting all parameters' do
           let(:params) do
             {
+              'dn_mode' => 'cn_only',
               'country' => 'CO',
               'province' => 'ST',
               'city' => 'Some City',
@@ -86,6 +82,7 @@ describe 'openvpn::ca', type: :define do
             }
           end
 
+          it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_DN="cn_only"$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CA_EXPIRE=365$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CERT_EXPIRE=365$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_REQ_CN="yolo"$}) }
@@ -111,11 +108,6 @@ describe 'openvpn::ca', type: :define do
           # Files associated with a server config
 
           it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with(mode: '0550') }
-
-          it {
-            is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/keys/crl.pem").
-              with(ensure: 'link', target: "#{server_directory}/test_server/crl.pem")
-          }
 
           it {
             is_expected.to contain_file("#{server_directory}/test_server/keys").
@@ -152,6 +144,7 @@ describe 'openvpn::ca', type: :define do
         context 'creating a ca setting all parameters' do
           let(:params) do
             {
+              'dn_mode' => 'cn_only',
               'country' => 'CO',
               'province' => 'ST',
               'city' => 'Some City',
@@ -169,6 +162,7 @@ describe 'openvpn::ca', type: :define do
           end
 
           if facts[:os]['release']['major'] =~ %r{10|11|20.04}
+            it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_DN="cn_only"$}) }
             it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CA_EXPIRE=365$}) }
             it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_CERT_EXPIRE=365$}) }
             it { is_expected.to contain_file("#{server_directory}/test_server/easy-rsa/vars").with_content(%r{^export EASYRSA_REQ_CN="yolo"$}) }

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -974,6 +974,18 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh.pem$}) }
         end
 
+        context 'creating a server in dn_mode cn_only' do
+          let(:params) do
+            {
+              'dn_mode' => 'cn_only',
+            }
+          end
+
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys/issued/server.crt$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys/private/server.key$}) }
+          it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh.pem$}) }
+        end
+
         context 'creating a server in client mode' do
           let(:title) { 'test_client' }
           let(:nobind) { false }

--- a/templates/vars-30.epp
+++ b/templates/vars-30.epp
@@ -81,16 +81,26 @@ export EASYRSA_CRL_DAYS=<%= $crl_days %>
 
 export EASYRSA_DIGEST=<%= $digest %>
 
-export EASYRSA_DN="org"
+export EASYRSA_DN="<%= $dn_mode %>"
 
 # These are the default values for fields
 # which will be placed in the certificate.
 # Don't leave any of these fields blank.
+<% if $country { -%>
 export EASYRSA_REQ_COUNTRY="<%= $country %>"
+<% } -%>
+<% if $province { -%>
 export EASYRSA_REQ_PROVINCE="<%= $province %>"
+<% } -%>
+<% if $city { -%>
 export EASYRSA_REQ_CITY="<%= $city %>"
+<% } -%>
+<% if $organization { -%>
 export EASYRSA_REQ_ORG="<%= $organization %>"
+<% } -%>
+<% if $email { -%>
 export EASYRSA_REQ_EMAIL="<%= $email %>"
+<% } -%>
 <% if $key_cn { -%>
 export EASYRSA_REQ_CN="<%= $key_cn %>"
 <% } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

In most of the time, the `Country/Province/City/Org/OU/email` are pointless for OpenVPN servers. easy-rsa introduce cn_only ad DN mode to omit `Country/Province/City/Org/OU/email` values.

```
# Define X509 DN mode.
# This is used to adjust what elements are included in the Subject field as the DN
# (this is the "Distinguished Name.")
# Note that in cn_only mode the Organizational fields further below are not used.
#
# Choices are:
#   cn_only  - use just a CN value
#   org      - use the "traditional" Country/Province/City/Org/OU/email/CN format

#set_var EASYRSA_DN	"cn_only"
```

This PR also remove the manual generation of the in favor of `easyrsa gen-crl` command, since the old variant was not compatible cn_only mode. `gen-crl` put the crl.pem in private folder of the easyrsa PKI folder, a manual copy is needed.

This PR is in draft mode for get some early reviews. Since this PR is in conflict with #431, I propose the focus should be on #431. After merge of #431, I'll do a rebase here.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
