### PR TITLE
Make ecdh-curve optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1339,11 +1339,11 @@ Default value: `'secp384r1'`
 
 ##### <a name="ecdh_curve"></a>`ecdh_curve`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Define the named curve for ECDH key exchange, used if ssl_key_algo is ec, ed
 
-Default value: `'secp384r1'`
+Default value: ``undef``
 
 ##### <a name="topology"></a>`topology`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -184,7 +184,7 @@ define openvpn::server (
   Enum['rsa', 'ec', 'ed'] $ssl_key_algo                             = 'rsa',
   Integer $ssl_key_size                                             = 2048,
   String $ssl_key_curve                                             = 'secp384r1',
-  String $ecdh_curve                                                = 'secp384r1',
+  Optional[String[1]] $ecdh_curve                                   = undef,
   String $topology                                                  = 'net30',
   Boolean $c2c                                                      = false,
   Boolean $tcp_nodelay                                              = false,

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -46,6 +46,8 @@ dh <%= @server_directory %>/<%= @ca_name %>/keys/dh<%= @ssl_key_size %>.pem
 dh <%= @server_directory %>/<%= @ca_name %>/keys/dh.pem
 <%- else -%>
 dh none
+<%- end -%>
+<%- if @ecdh_curve -%>
 ecdh-curve <%= @ecdh_curve %>
 <%- end -%>
 <%   end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

Make ecdh-curve optional, if no dh key is defined.

In OpenVPN 2.5 (I initially test the EC keys with OpenVPN 2.4), define ecdh-curve will throw an warning

> Consider setting groups/curves preference with tls-groups instead of forcing a specific curve with ecdh-curve.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
