### PR TITLE
Fix path for crl_auto_renew with easy_rsa 3.0

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -409,7 +409,7 @@ define openvpn::server (
           }
           '3.0': {
             exec { "renew crl.pem on ${name}":
-              command  => "./easyrsa gen-crl && cp ./keys/crl.pem ${server_directory}/${server}/crl.pem",
+              command  => "./easyrsa gen-crl && cp ./keys/crl.pem ${server_directory}/${name}/crl.pem",
               cwd      => "${server_directory}/${name}/easy-rsa",
               provider => 'shell',
               schedule => "renew crl.pem schedule on ${name}",

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -585,6 +585,7 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys/mylittlepony.crt$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys/mylittlepony.key$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh2048.pem$}) }
+          it { is_expected.to contain_exec('renew crl.pem on test_server').with('command' => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out #{server_directory}/test_server/crl.pem -config #{server_directory}/test_server/easy-rsa/openssl.cnf") }
         end
 
         context 'creating a server in client mode' do
@@ -972,6 +973,7 @@ describe 'openvpn::server' do
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^cert\s+#{server_directory}/test_server/keys/issued/mylittlepony.crt$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^key\s+#{server_directory}/test_server/keys/private/mylittlepony.key$}) }
           it { is_expected.to contain_file("#{server_directory}/test_server.conf").with_content(%r{^dh\s+#{server_directory}/test_server/keys/dh.pem$}) }
+          it { is_expected.to contain_exec('renew crl.pem on test_server').with('command' => "./easyrsa gen-crl && cp ./keys/crl.pem #{server_directory}/test_server/crl.pem") }
         end
 
         context 'creating a server in dn_mode cn_only' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Small patch to fix the path of crl.pem introduced by https://github.com/voxpupuli/puppet-openvpn/pull/432 by @jkroepke
The cp fail with : 
```
'./easyrsa gen-crl && cp ./keys/crl.pem /etc/openvpn/10.9.200.0 255.255.255.0/crl.pem' returned 1 instead of one of [0]
change from 'notrun' to ['0'] failed: './easyrsa gen-crl && cp ./keys/crl.pem /etc/openvpn/10.9.200.0 255.255.255.0/crl.pem' returned 1 instead of one of [0] (corrective)
```
Certainly a cut and paste problem. In manifests/revoke.pp, $server is the correct variable but not in server.pp
