### PR TITLE
Support data-ciphers and data-ciphers-fallback options

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -451,6 +451,8 @@ The following parameters are available in the `openvpn::client` defined type:
 * [`remote_host`](#-openvpn--client--remote_host)
 * [`cipher`](#-openvpn--client--cipher)
 * [`tls_cipher`](#-openvpn--client--tls_cipher)
+* [`data_ciphers`](#-openvpn--client--data_ciphers)
+* [`data_ciphers_fallback`](#-openvpn--client--data_ciphers_fallback)
 * [`resolv_retry`](#-openvpn--client--resolv_retry)
 * [`auth_retry`](#-openvpn--client--auth_retry)
 * [`verb`](#-openvpn--client--verb)
@@ -574,6 +576,22 @@ Data type: `String`
 TLS Ciphers to use
 
 Default value: `'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256'`
+
+##### <a name="-openvpn--client--data_ciphers"></a>`data_ciphers`
+
+Data type: `String`
+
+Ciphers to allow for packet encryption
+
+Default value: `'AES-256-GCM:AES-128-GCM'`
+
+##### <a name="-openvpn--client--data_ciphers_fallback"></a>`data_ciphers_fallback`
+
+Data type: `Optional[String]`
+
+Cipher to use if peer cipher config cannot be determined
+
+Default value: `undef`
 
 ##### <a name="-openvpn--client--resolv_retry"></a>`resolv_retry`
 
@@ -1030,6 +1048,8 @@ The following parameters are available in the `openvpn::server` defined type:
 * [`verb`](#-openvpn--server--verb)
 * [`cipher`](#-openvpn--server--cipher)
 * [`tls_cipher`](#-openvpn--server--tls_cipher)
+* [`data_ciphers`](#-openvpn--server--data_ciphers)
+* [`data_ciphers_fallback`](#-openvpn--server--data_ciphers_fallback)
 * [`persist_key`](#-openvpn--server--persist_key)
 * [`persist_tun`](#-openvpn--server--persist_tun)
 * [`key_expire`](#-openvpn--server--key_expire)
@@ -1626,6 +1646,22 @@ Data type: `String`
 TLS Ciphers to use
 
 Default value: `'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256'`
+
+##### <a name="-openvpn--server--data_ciphers"></a>`data_ciphers`
+
+Data type: `String`
+
+Ciphers to allow for packet encryption
+
+Default value: `'AES-256-GCM:AES-128-GCM'`
+
+##### <a name="-openvpn--server--data_ciphers_fallback"></a>`data_ciphers_fallback`
+
+Data type: `Optional[String]`
+
+Cipher to use if peer cipher config cannot be determined
+
+Default value: `undef`
 
 ##### <a name="-openvpn--server--persist_key"></a>`persist_key`
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -14,6 +14,8 @@
 # @param remote_host  The IP or hostname of the openvpn server service.
 # @param cipher Cipher to use for packet encryption
 # @param tls_cipher TLS Ciphers to use
+# @param data_ciphers Ciphers to allow for packet encryption
+# @param data_ciphers_fallback Cipher to use if peer cipher config cannot be determined
 # @param resolv_retry  How many seconds should the openvpn client try to resolve the server's hostname
 # @param auth_retry Controls how OpenVPN responds to username/password verification errors such as the client-side response to an AUTH_FAILED message from the server or verification failure of the private key password.
 # @param verb Level of logging verbosity
@@ -61,6 +63,8 @@ define openvpn::client (
   Boolean $pam                                         = false,
   String $cipher                                       = 'AES-256-GCM',
   String $tls_cipher                                   = 'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256',
+  String $data_ciphers                                 = 'AES-256-GCM:AES-128-GCM',
+  Optional[String] $data_ciphers_fallback              = undef,
   Boolean $authuserpass                                = false,
   Hash $setenv                                         = {},
   Hash $setenv_safe                                    = {},

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -71,6 +71,8 @@
 # @param verb Level of logging verbosity
 # @param cipher Cipher to use for packet encryption
 # @param tls_cipher TLS Ciphers to use
+# @param data_ciphers Ciphers to allow for packet encryption
+# @param data_ciphers_fallback Cipher to use if peer cipher config cannot be determined
 # @param persist_key Try to retain access to resources that may be unavailable because of privilege downgrades
 # @param persist_tun  Try to retain access to resources that may be unavailable because of privilege downgrades
 # @param key_expire The number of days to certify the server certificate for
@@ -225,6 +227,8 @@ define openvpn::server (
   Optional[String] $verb                                            = undef,
   String $cipher                                                    = 'AES-256-GCM',
   String $tls_cipher                                                = 'TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-128-CBC-SHA256',
+  String $data_ciphers                                              = 'AES-256-GCM:AES-128-GCM',
+  Optional[String] $data_ciphers_fallback                           = undef,
   Boolean $persist_key                                              = false,
   Boolean $persist_tun                                              = false,
   Boolean $tls_auth                                                 = false,

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -196,6 +196,8 @@ describe 'openvpn::client' do
             'persist_tun' => false,
             'cipher' => 'AES-256-GCM',
             'tls_cipher' => 'TLS-DHE-RSA-WITH-AES-256-CBC-SHA',
+            'data_ciphers' => 'AES-256-GCM',
+            'data_ciphers_fallback' => 'AES-128-GCM',
             'port' => '123',
             'proto' => 'udp',
             'remote_host' => %w[somewhere galaxy],
@@ -233,6 +235,8 @@ describe 'openvpn::client' do
             with_content(%r{^setenv_safe\s+FORWARD_COMPATIBLE\s+1$}).
             with_content(%r{^cipher\s+AES-256-GCM$}).
             with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}).
+            with_content(%r{^data-ciphers\s+AES-256-GCM$}).
+            with_content(%r{^data-ciphers-fallback\s+AES-128-GCM$}).
             with_content(%r{^tls-client$}).
             with_content(%r{^verify-x509-name\s+"test_server"\s+name$}).
             with_content(%r{^sndbuf\s+393216$}).

--- a/spec/defines/openvpn_server_spec.rb
+++ b/spec/defines/openvpn_server_spec.rb
@@ -478,6 +478,8 @@ describe 'openvpn::server' do
             'verb' => 'mute',
             'cipher' => 'DES-CBC',
             'tls_cipher' => 'TLS-DHE-RSA-WITH-AES-256-CBC-SHA',
+            'data_ciphers' => 'AES-256-GCM',
+            'data_ciphers_fallback' => 'AES-128-GCM',
             'persist_key' => true,
             'persist_tun' => true,
             'duplicate_cn' => true,
@@ -517,6 +519,8 @@ describe 'openvpn::server' do
             with_content(%r{^verb mute$}).
             with_content(%r{^cipher DES-CBC$}).
             with_content(%r{^tls-cipher\s+TLS-DHE-RSA-WITH-AES-256-CBC-SHA$}).
+            with_content(%r{^data-ciphers\s+AES-256-GCM$}).
+            with_content(%r{^data-ciphers-fallback\s+AES-128-GCM$}).
             with_content(%r{^persist-key$}).
             with_content(%r{^persist-tun$}).
             with_content(%r{^up "/tmp/up"$}).

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -28,6 +28,12 @@ cipher <%= @cipher %>
 <% if @tls_cipher != '' -%>
 tls-cipher <%= @tls_cipher %>
 <% end -%>
+<% if @data_ciphers != 'AES-256-GCM:AES-128-GCM' -%>
+data-ciphers <%= @data_ciphers %>
+<% end -%>
+<% if @data_ciphers_fallback -%>
+data-ciphers-fallback <%= @data_ciphers_fallback %>
+<% end -%>
 <% if @mute_replay_warnings -%>
 mute-replay-warnings
 <% end -%>

--- a/templates/server.erb
+++ b/templates/server.erb
@@ -136,6 +136,12 @@ cipher <%= @cipher %>
 <% if @tls_cipher != '' -%>
 tls-cipher <%= @tls_cipher %>
 <% end -%>
+<% if @data_ciphers != 'AES-256-GCM:AES-128-GCM' -%>
+data-ciphers <%= @data_ciphers %>
+<% end -%>
+<% if @data_ciphers_fallback -%>
+data-ciphers-fallback <%= @data_ciphers_fallback %>
+<% end -%>
 <% if @c2c -%>
 client-to-client
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Support `data-ciphers` and `data-ciphers-fallback` options for OpenVPN 2.5.

#### This Pull Request (PR) fixes the following issues: n/a