### PR TITLE
Relax dependencies version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 10.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 8.0.0"
+      "version_requirement": ">= 4.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
- Allow puppetlabs-stdlib 9.x
- Allow puppetlabs-concat 9.x
