### PR TITLE
Update to the latest EasyRSA 3.x vars file syntax

### DIFF
--- a/templates/vars-30.epp
+++ b/templates/vars-30.epp
@@ -1,109 +1,256 @@
-# easy-rsa parameter settings
+# Easy-RSA 3 parameter settings
 
-# NOTE: If you installed from an RPM,
-# don't edit this file in place in
-# /usr/share/openvpn/easy-rsa --
-# instead, you should copy the whole
-# easy-rsa directory to another location
-# (such as /etc/openvpn) so that your
-# edits will not be wiped out by a future
-# OpenVPN package upgrade.
+# NOTE: If you installed Easy-RSA from your package manager, do not edit
+# this file in place -- instead, you should copy the entire easy-rsa directory
+# to another location so future upgrades do not wipe out your changes.
 
-# This variable should point to
-# the top level of the easy-rsa
-# tree.
-export EASY_RSA="<%= $server_directory -%>/<%= $openvpn_server %>/easy-rsa"
-
+# HOW TO USE THIS FILE
 #
-# This variable should point to
-# the requested executables
+# vars.example contains built-in examples to Easy-RSA settings. You MUST name
+# this file "vars" if you want it to be used as a configuration file. If you
+# do not, it WILL NOT be automatically read when you call easyrsa commands.
 #
-export EASYRSA_OPENSSL="openssl"
-export PKCS11TOOL="pkcs11-tool"
-export GREP="grep"
-
-
-# This variable should point to
-# the openssl.cnf file included
-# with easy-rsa.
-export EASYRSA_SSL_CONF="$EASY_RSA/openssl-1.0.cnf"
-
-# Edit this variable to point to
-# your soon-to-be-created key
-# directory.
+# It is not necessary to use this config file unless you wish to change
+# operational defaults. These defaults should be fine for many uses without
+# the need to copy and edit the "vars" file.
 #
-# WARNING: clean-all will do
-# a rm -rf on this directory
-# so make sure you define
-# it correctly!
-export EASYRSA_PKI="$EASY_RSA/keys"
+# All of the editable settings are shown commented and start with the command
+# "set_var" -- this means any set_var command that is uncommented has been
+# modified by the user. If you are happy with a default, there is no need to
+# define the value to its default.
 
-# Issue rm -rf warning
-echo NOTE: If you run ./clean-all, I will be doing a rm -rf on $EASYRSA_PKI
+# NOTES FOR WINDOWS USERS
+#
+# Paths for Windows  *MUST* use forward slashes, or optionally double-escaped
+# backslashes (single forward slashes are recommended.) This means your path
+# to the openssl binary might look like this:
+# "C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
 
-# PKCS11 fixes
-export PKCS11_MODULE_PATH="dummy"
-export PKCS11_PIN="dummy"
+# A little housekeeping: DO NOT EDIT THIS SECTION
+#
+# Easy-RSA 3.x does not source into the environment directly.
+# Complain if a user tries to do this:
+if [ -z "$EASYRSA_CALLER" ]; then
+	echo "You appear to be sourcing an Easy-RSA *vars* file. This is" >&2
+	echo "no longer necessary and is disallowed. See the section called" >&2
+	echo "*How to use this file* near the top comments for more details." >&2
+	return 1
+fi
 
-# Increase this to 2048 if you
-# are paranoid.  This will slow
-# down TLS negotiation performance
-# as well as the one-time DH parms
-# generation process.
-export EASYRSA_KEY_SIZE=<%= $ssl_key_size %>
+# DO YOUR EDITS BELOW THIS POINT
+
+# This variable is used as the base location of configuration files needed by
+# easyrsa.  More specific variables for specific files (eg: EASYRSA_SSL_CONF)
+# may override this default.
+#
+# The default value of this variable is the location of the easyrsa script
+# itself, which is also where the configuration files are located in the
+# easy-rsa tree.
+#
+set_var EASYRSA	"<%= $server_directory -%>/<%= $openvpn_server %>/easy-rsa"
+
+set_var EASYRSA_PKI "$EASYRSA/keys"
+
+# If your OpenSSL command is not in the system PATH, you will need to define
+# the path here. Normally this means a full path to the executable, otherwise
+# you could have left it undefined here and the shown default would be used.
+#
+# Windows users, remember to use paths with forward-slashes (or escaped
+# back-slashes.) Windows users should declare the full path to the openssl
+# binary here if it is not in their system PATH.
+#
+set_var EASYRSA_OPENSSL	"openssl"
+#
+# This sample is in Windows syntax -- edit it for your path if not using PATH:
+#set_var EASYRSA_OPENSSL	"C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
+
+# Define X509 DN mode.
+#
+# This is used to adjust which elements are included in the Subject field
+# as the DN ("Distinguished Name"). Note that in 'cn_only' mode the
+# Organizational fields, listed further below, are not used.
+#
+# Choices are:
+#   cn_only  - Use just a commonName value.
+#   org      - Use the "traditional" format:
+#              Country/Province/City/Org/Org.Unit/email/commonName
+#
+set_var EASYRSA_DN	"<%= $dn_mode %>"
+
+# Organizational fields (used with "org" mode and ignored in "cn_only" mode).
+# These are the default values for fields which will be placed in the
+# certificate.  Do not leave any of these fields blank, although interactively
+# you may omit any specific field by typing the "." symbol (not valid for
+# email).
+#
+# NOTE: The following characters are not supported
+#       in these "Organizational fields" by Easy-RSA:
+#       back-tick (`)
+#
+<% if $country { -%>
+set_var EASYRSA_REQ_COUNTRY	"<%= $country %>"
+<% } -%>
+<% if $province { -%>
+set_var EASYRSA_REQ_PROVINCE	"<%= $province %>"
+<% } -%>
+<% if $city { -%>
+set_var EASYRSA_REQ_CITY	"<%= $city %>"
+<% } -%>
+<% if $organization { -%>
+set_var EASYRSA_REQ_ORG	"<%= $organization %>"
+<% } -%>
+<% if $email { -%>
+set_var EASYRSA_REQ_EMAIL	"<%= $email %>"
+<% } -%>
+<% if $key_cn { -%>
+set_var EASYRSA_REQ_CN	"<%= $key_cn %>"
+<% } -%>
+<% if $key_ou { -%>
+set_var EASYRSA_REQ_OU	"<%= $key_ou %>"
+<% } -%>
+
+# Preserve the Distinguished Name field order
+# of the certificate signing request
+# *Only* effective in --dn-mode=org
+#
+#set_var EASYRSA_PRESERVE_DN	1
+
+# Set no password mode - This will create the entire PKI without passwords.
+# This can be better managed by choosing which entity private keys should be
+# encrypted with the following command line options:
+# Global option '--no-pass' or command option 'nopass'.
+#
+#set_var EASYRSA_NO_PASS	1
+
+# Choose a size in bits for your keypairs. The recommended value is 2048.
+# Using 2048-bit keys is considered more than sufficient for many years into
+# the future. Larger keysizes will slow down TLS negotiation and make key/DH
+# param generation take much longer. Values up to 4096 should be accepted by
+# most software. Only used when the crypto alg is rsa, see below.
+#
+set_var EASYRSA_KEY_SIZE	<%= $ssl_key_size %>
 
 # The default crypto mode is rsa; ec can enable elliptic curve support.
 # Note that not all software supports ECC, so use care when enabling it.
 # Choices for crypto alg are: (each in lower-case)
 #  * rsa
 #  * ec
-
+#  * ed
+#
 <% if $ssl_key_algo { -%>
-export EASYRSA_ALGO=<%= $ssl_key_algo %>
+set_var EASYRSA_ALGO	<%= $ssl_key_algo %>
 <% } -%>
-# Define the named curve, used in ec mode only:
 
+# Define the named curve, used in ec & ed modes:
+#
 <% if $ssl_key_curve { -%>
-export EASYRSA_CURVE=<%= $ssl_key_curve %>
+set_var EASYRSA_CURVE	<%= $ssl_key_curve %>
 <% } -%>
 
 # In how many days should the root CA key expire?
-export EASYRSA_CA_EXPIRE=<%= $ca_expire %>
+#
+set_var EASYRSA_CA_EXPIRE	<%= $ca_expire %>
 
 # In how many days should certificates expire?
-export EASYRSA_CERT_EXPIRE=<%= $key_expire %>
+#
+set_var EASYRSA_CERT_EXPIRE	<%= $key_expire %>
 
-export EASYRSA_CRL_DAYS=<%= $crl_days %>
+# How many days until the Certificate Revokation List will expire.
+#
+# IMPORTANT: When the CRL expires, an OpenVPN Server which uses a
+# CRL will reject ALL new connections, until the CRL is replaced.
+#
+set_var EASYRSA_CRL_DAYS	<%= $crl_days %>
+
+# Random serial numbers by default.
+# Set to 'no' for the old incremental serial numbers.
+#
+#set_var EASYRSA_RAND_SN	"yes"
+
+# Cut-off window for checking expiring certificates.
+#
+#set_var EASYRSA_PRE_EXPIRY_WINDOW	90
+
+# Generate automatic subjectAltName for certificates
+#
+#set_var	EASYRSA_AUTO_SAN	1
+
+# Add critical attribute to X509 fields: basicConstraints (BC),
+# keyUsage (KU), extendedKeyUsage (EKU) or SAN
+#
+#set_var	EASYRSA_BC_CRIT		1
+#set_var	EASYRSA_KU_CRIT		1
+#set_var	EASYRSA_EKU_CRIT	1
+#set_var	EASYRSA_SAN_CRIT	1
+
+# Disable automatic inline files
+#
+#set_var	EASYRSA_DISABLE_INLINE	1
+
+# Support deprecated "Netscape" extensions? (choices "yes" or "no").
+# The default is "no", to discourage use of deprecated extensions.
+# If you require this feature to use with --ns-cert-type, set this to "yes".
+# This support should be replaced with the more modern --remote-cert-tls
+# feature.  If you do not use --ns-cert-type in your configs, it is safe,
+# and recommended, to leave this defined to "no".
+# When set to "yes", server-signed certs get the nsCertType=server attribute
+# and also get any NS_COMMENT defined below in the nsComment field.
+#
+#set_var EASYRSA_NS_SUPPORT	"no"
+
+# When NS_SUPPORT is set to "yes", this field is added as the nsComment field.
+# Set this blank to omit it. With NS_SUPPORT set to "no" this field is ignored.
+#
+#set_var EASYRSA_NS_COMMENT	"Easy-RSA Generated Certificate"
+
+# !!
+# NOTE: ADVANCED OPTIONS BELOW THIS POINT
+# PLAY WITH THEM AT YOUR OWN RISK
+# !!
+
+# Broken shell command aliases: If you have a largely broken shell that is
+# missing any of these POSIX-required commands used by Easy-RSA, you will need
+# to define an alias to the proper path for the command.  The symptom will be
+# some form of a "command not found" error from your shell. This means your
+# shell is BROKEN, but you can hack around it here if you really need. These
+# shown values are not defaults: it is up to you to know what you are doing if
+# you touch these.
+#
+#alias awk="/alt/bin/awk"
+#alias cat="/alt/bin/cat"
+
+# X509 extensions directory:
+# If you want to customize the X509 extensions used, set the directory to look
+# for extensions here. Each cert type you sign must have a matching filename,
+# and an optional file named "COMMON" is included first when present. Note that
+# when undefined here, default behaviour is to look in $EASYRSA_PKI first, then
+# fallback to $EASYRSA for the "x509-types" dir.  You may override this
+# detection with an explicit dir here.
+#
+#set_var EASYRSA_EXT_DIR	"$EASYRSA/x509-types"
+
+# Non-functional
+# If you want to generate KDC certificates, you need to set the realm here.
+#
+#set_var EASYRSA_KDC_REALM      "CHANGEME.EXAMPLE.COM"
+
+# OpenSSL config file:
+# If you need to use a specific openssl config file, you can reference it here.
+# Normally this file is auto-detected from a file named openssl-easyrsa.cnf
+# from the EASYRSA_PKI or EASYRSA dir, in that order. NOTE that this file is
+# Easy-RSA specific and you cannot just use a standard config file, so this is
+# an advanced feature.
+#
+set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
 
 # Cryptographic digest to use.
 # Do not change this default unless you understand the security implications.
 # Valid choices include: md5, sha1, sha256, sha224, sha384, sha512
+#
+set_var EASYRSA_DIGEST		<%= $digest %>
 
-export EASYRSA_DIGEST=<%= $digest %>
-
-export EASYRSA_DN="<%= $dn_mode %>"
-
-# These are the default values for fields
-# which will be placed in the certificate.
-# Don't leave any of these fields blank.
-<% if $country { -%>
-export EASYRSA_REQ_COUNTRY="<%= $country %>"
-<% } -%>
-<% if $province { -%>
-export EASYRSA_REQ_PROVINCE="<%= $province %>"
-<% } -%>
-<% if $city { -%>
-export EASYRSA_REQ_CITY="<%= $city %>"
-<% } -%>
-<% if $organization { -%>
-export EASYRSA_REQ_ORG="<%= $organization %>"
-<% } -%>
-<% if $email { -%>
-export EASYRSA_REQ_EMAIL="<%= $email %>"
-<% } -%>
-<% if $key_cn { -%>
-export EASYRSA_REQ_CN="<%= $key_cn %>"
-<% } -%>
-<% if $key_ou { -%>
-export EASYRSA_REQ_OU="<%= $key_ou %>"
-<% } -%>
+# Batch mode. Leave this disabled unless you intend to call Easy-RSA explicitly
+# in batch mode without any user input, confirmation on dangerous operations,
+# or most output. Setting this to any non-blank string enables batch mode.
+#
+#set_var EASYRSA_BATCH		""


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where EasyRSA 3.1.3 and later would fail with the following error:
```
These problems have been found in your 'vars' settings:
Use of 'export':
Remove 'export' or replace it with 'set_var'.
```

#### This Pull Request (PR) fixes the following issues
Fixes #417 