### PR TITLE
Allow client_specific_config with extca_enabled

### DIFF
--- a/manifests/client_specific_config.pp
+++ b/manifests/client_specific_config.pp
@@ -38,7 +38,6 @@ define openvpn::client_specific_config (
 ) {
   if $manage_client_configs {
     Openvpn::Server[$server]
-    -> Openvpn::Client[$name]
     -> Openvpn::Client_specific_config[$name]
   } else {
     Openvpn::Server[$server]

--- a/spec/defines/openvpn_client_specific_config_spec.rb
+++ b/spec/defines/openvpn_client_specific_config_spec.rb
@@ -6,13 +6,13 @@ describe 'openvpn::client_specific_config', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:pre_condition) do
-          'openvpn::server { "test_server":
-            country       => "CO",
-            province      => "ST",
-            city          => "Some City",
-            organization  => "example.org",
-            email         => "testemail@example.org"
-          }'
+        'openvpn::server { "test_server":
+           country       => "CO",
+           province      => "ST",
+           city          => "Some City",
+           organization  => "example.org",
+           email         => "testemail@example.org"
+        }'
       end
       let(:facts) do
         facts

--- a/spec/defines/openvpn_client_specific_config_spec.rb
+++ b/spec/defines/openvpn_client_specific_config_spec.rb
@@ -6,18 +6,13 @@ describe 'openvpn::client_specific_config', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:pre_condition) do
-        [
           'openvpn::server { "test_server":
             country       => "CO",
             province      => "ST",
             city          => "Some City",
             organization  => "example.org",
             email         => "testemail@example.org"
-          }',
-          'openvpn::client { "test_client":
-            server => "test_server"
           }'
-        ].join
       end
       let(:facts) do
         facts


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
There is an issue where the client_specific_config type cannot be used alongside an externally configured Certificate Authority (CA). When extca_enabled is set to true, the existing dependency on openvpn::client causes conflicts, preventing the configuration from working properly. This update eliminates the dependency, enabling the client_specific_config type to function seamlessly with external CA configurations.
<!--
-->

#### This Pull Request (PR) fixes the following issues
This update eliminates the dependency, enabling the client_specific_config type to function seamlessly with external CA configurations.
<!--
-->
