### PR TITLE
Add `private_key_password` parameter to allow setting private key passwords

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -498,6 +498,7 @@ The following parameters are available in the `openvpn::client` defined type:
 * [`pull`](#-openvpn--client--pull)
 * [`server_extca_enabled`](#-openvpn--client--server_extca_enabled)
 * [`remote_cert_tls`](#-openvpn--client--remote_cert_tls)
+* [`private_key_password`](#-openvpn--client--private_key_password)
 
 ##### <a name="-openvpn--client--server"></a>`server`
 
@@ -768,6 +769,14 @@ Data type: `Boolean`
 Enable or disable use of remote-cert-tls used with client configuration
 
 Default value: `true`
+
+##### <a name="-openvpn--client--private_key_password"></a>`private_key_password`
+
+Data type: `Optional[String]`
+
+Optional password to protect the generated private key. If set, the key is not generated with "nopass" but instead EASYRSA_PASSOUT is set accordingly.
+
+Default value: `undef`
 
 ### <a name="openvpn--client_specific_config"></a>`openvpn::client_specific_config`
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -35,6 +35,7 @@
 # @param pull Allow server to push options like dns or routes
 # @param server_extca_enabled Turn this on if you are using an external CA solution, like FreeIPA. Use this in Combination with exported_ressourced, since they don't have Access to the Serverconfig
 # @param remote_cert_tls Enable or disable use of remote-cert-tls used with client configuration
+# @param private_key_password Optional password to protect the generated private key. If set, the key is not generated with "nopass" but instead EASYRSA_PASSOUT is set accordingly.
 #
 # @example
 #   openvpn::client {
@@ -78,6 +79,7 @@ define openvpn::client (
   Boolean $pull                                        = false,
   Boolean $server_extca_enabled                        = false,
   Boolean $remote_cert_tls                             = true,
+  Optional[String] $private_key_password               = undef,
 ) {
   if $pam {
     warning('Using $pam is deprecated. Use $authuserpass instead!')
@@ -109,7 +111,7 @@ define openvpn::client (
     if is_integer($expire) {
       case $openvpn::easyrsa_version {
         '3.0': {
-          $env_expire = "EASYRSA_CERT_EXPIRE=${expire} EASYRSA_NO_VARS=1"
+          $env_expire = ['EASYRSA_NO_VARS=1', "EASYRSA_CERT_EXPIRE=${expire}"]
         }
         default: {
           fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 3.0.")
@@ -117,18 +119,27 @@ define openvpn::client (
       }
     } else {
       warning("Custom expiry time ignored: only integer is accepted but ${expire} is given.")
+      $env_expire = []
     }
   } else {
-    $env_expire = ''
+    $env_expire = []
   }
+
+  $env_passout = $private_key_password ? {
+    undef   => ['EASYRSA_NO_PASS=1'],
+    default => ["EASYRSA_PASSOUT=pass:${private_key_password}"],
+  }
+
+  $easyrsa_environment = $env_expire + $env_passout
 
   case $openvpn::easyrsa_version {
     '3.0': {
       exec { "generate certificate for ${name} in context of ${ca_name}":
-        command  => "${env_expire} ./easyrsa --batch build-client-full ${name} nopass",
-        cwd      => "${server_directory}/${ca_name}/easy-rsa",
-        creates  => "${server_directory}/${ca_name}/easy-rsa/keys/issued/${name}.crt",
-        provider => 'shell';
+        command     => "./easyrsa --batch build-client-full ${name}",
+        cwd         => "${server_directory}/${ca_name}/easy-rsa",
+        creates     => "${server_directory}/${ca_name}/easy-rsa/keys/issued/${name}.crt",
+        provider    => 'shell',
+        environment => $easyrsa_environment;
       }
 
       file { "${server_directory}/${server}/download-configs/${name}/keys/${name}/${name}.crt":


### PR DESCRIPTION
This adds a `private_key_password` parameter to the `openvpn::client` define. The given password will be passed on to `easyrsa` through the `EASYRSA_PASSOUT` environment variable. 

This way, the generated private key for the client, which is contained in the exported `.ovpn` config files, is protected with a password.

The OpenVPN Connect client will ask for the key password when establishing the connection.

