### PR TITLE
Add custom options for easyrsa client certificate generation command

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -498,6 +498,7 @@ The following parameters are available in the `openvpn::client` defined type:
 * [`pull`](#-openvpn--client--pull)
 * [`server_extca_enabled`](#-openvpn--client--server_extca_enabled)
 * [`remote_cert_tls`](#-openvpn--client--remote_cert_tls)
+* [`custom_easyrsa_options`](#-openvpn--client--custom_easyrsa_options)
 
 ##### <a name="-openvpn--client--server"></a>`server`
 
@@ -768,6 +769,14 @@ Data type: `Boolean`
 Enable or disable use of remote-cert-tls used with client configuration
 
 Default value: `true`
+
+##### <a name="-openvpn--client--custom_easyrsa_options"></a>`custom_easyrsa_options`
+
+Data type: `Array`
+
+Add custom options to the easyrsa command
+
+Default value: `[]`
 
 ### <a name="openvpn--client_specific_config"></a>`openvpn::client_specific_config`
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -35,6 +35,7 @@
 # @param pull Allow server to push options like dns or routes
 # @param server_extca_enabled Turn this on if you are using an external CA solution, like FreeIPA. Use this in Combination with exported_ressourced, since they don't have Access to the Serverconfig
 # @param remote_cert_tls Enable or disable use of remote-cert-tls used with client configuration
+# @param custom_easyrsa_options Add custom options to the easyrsa command
 #
 # @example
 #   openvpn::client {
@@ -78,6 +79,7 @@ define openvpn::client (
   Boolean $pull                                        = false,
   Boolean $server_extca_enabled                        = false,
   Boolean $remote_cert_tls                             = true,
+  Array $custom_easyrsa_options                        = [],
 ) {
   if $pam {
     warning('Using $pam is deprecated. Use $authuserpass instead!')
@@ -125,7 +127,7 @@ define openvpn::client (
   case $openvpn::easyrsa_version {
     '3.0': {
       exec { "generate certificate for ${name} in context of ${ca_name}":
-        command  => "${env_expire} ./easyrsa --batch build-client-full ${name} nopass",
+        command  => "${env_expire} ./easyrsa --batch ${join($custom_easyrsa_options, ' ')} build-client-full ${name} nopass",
         cwd      => "${server_directory}/${ca_name}/easy-rsa",
         creates  => "${server_directory}/${ca_name}/easy-rsa/keys/issued/${name}.crt",
         provider => 'shell';


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds custom options for the easyrsa command, which is used to create client certs.
I've had the problem that Openssl text output was added to the client cert and therefore also to the client configuration file.
Since Easyrsa [v3.2.5 the '--notext' Option](https://github.com/OpenVPN/easy-rsa/blob/v3.2.5/doc/EasyRSA-Advanced.md) is available, which suppresses the text output.
Because it is not available in older 3.x versions I did not want to hardcode it and a more general approach adds more flexibility.